### PR TITLE
refactor: modularize main lifecycle and document smithery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env and fill in any keys required for your environment.
+# Leave values blank to disable the corresponding integration.
+
+# Optional: enables Brave web search integration.
+BRAVE_API_KEY=
+
+# Optional: enables OpenRouter-powered AI responses.
+OPENROUTER_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 out
 .DS_Store
 *.log*
+.env

--- a/README.md
+++ b/README.md
@@ -89,6 +89,34 @@ graph LR
     end
 ```
 
+#### Main process lifecycle
+
+The Electron main process is now organised into small lifecycle utilities so contributors can refactor or extend behaviour without digging through a monolithic `index.ts` file:
+
+| Concern | Module | Responsibilities |
+| --- | --- | --- |
+| Window orchestration | `src/main/lifecycle/window-manager.ts` | Builds the translucent shell window, wires blur/close hooks, and loads the correct renderer URL depending on environment. |
+| IPC routing | `src/main/lifecycle/ipc.ts` | Registers the tRPC bridge against the active window so renderer modules can call into the main process. |
+| Tray & shortcuts | `src/main/lifecycle/tray.ts`, `src/main/lifecycle/shortcuts.ts` | Sets up the status bar tray menu and keyboard toggle with graceful teardown on quit. |
+| Search database lifecycle | `src/main/lifecycle/search-service.ts` | Lazily initialises the embedded vector index, streams progress updates to the renderer, and persists/shuts down cleanly. |
+
+These modules keep the bootstrap logic declarative inside `src/main/index.ts` while still exposing focused hooks for new background services or observability.
+
+#### Renderer state toolkit
+
+To keep the liquid-glass UI responsive, the renderer has been decomposed into focused utilities instead of one monolithic `App.tsx`:
+
+| Concern | Module | Responsibilities |
+| --- | --- | --- |
+| Smithery connectors | `src/renderer/src/hooks/useSmitheryContext.ts` | Debounced MCP fetching with cancellation, error surfacing, and manual refresh support. |
+| Context scoring | `src/renderer/src/hooks/useContextScoring.ts` | Reranks merged local/MCP documents and tracks cosine similarity maps without blocking the UI thread. |
+| Prompt assembly | `src/renderer/src/lib/context-builder.ts` | Normalises sticky notes, Smithery snippets, and search results into a bounded context string for the LLM middleware. |
+| Shared search types | `src/renderer/src/types/search.ts` | Source of truth for search result, cache, and sticky note shapes reused across components. |
+
+These modules let feature components subscribe to just the slices of data they need, improving readability while reducing redundant network requests and state churn.
+
+> **Secrets stay local.** Configuration lives in `.env` (ignored by git) with safe defaults documented in `.env.example`; never commit API keys to the repo.
+
 ### Search Flow
 
 ```mermaid
@@ -122,7 +150,31 @@ sequenceDiagram
 - ⌨️ Global keyboard shortcuts (`Option (⌥) + Space`)
 - 💾 Smart caching system
 - 🎯 Context-aware search results
+- 🫧 Liquid glass interface inspired by macOS Sonoma
 - 📱 Modern, responsive UI
+
+### Liquid Glass Interface
+
+The renderer has been refreshed to echo Apple's latest "liquid glass" design language:
+
+- Layered frosted panels with animated gradient orbs and a soft grid backdrop keep the workspace calm yet dynamic.
+- A sculpted header surfaces key stats (pinned notes, surfaced results, conversations) so you can gauge context at a glance.
+- Search, chat, and notes live inside glass panels with softened borders, luminous highlights, and adaptive blur so focus stays on your content.
+- Sticky notes inherit the same frosted aesthetic and can be spawned instantly from the header or via <kbd>⌘/Ctrl</kbd> + <kbd>N</kbd>.
+
+To tweak the visuals, inspect `src/renderer/src/assets/index.css` for theme tokens and glass utilities, and adjust the panel layout inside `src/renderer/src/App.tsx`.
+
+### Smithery MCP connectors
+
+alBERT now speaks the [Model Context Protocol (MCP)](https://smithery.ai/mcp) so you can stream structured knowledge packs straight from [Smithery](https://smithery.ai) into every search and chat turn.
+
+1. **Open Settings → Smithery MCP** and (optionally) drop in your Smithery API key if you need private connectors.
+2. Paste a Smithery slug (for example `notion-notes`) or a manifest URL to link a connector. You can also pick from the built-in directory and click **Link connector**.
+3. Toggle connectors on/off, refresh their metadata, or remove them entirely without editing config files.
+
+Once linked, context cards from each connector show up beneath search results. The retrieved snippets are automatically blended into the conversation context so the assistant can cite them alongside your local documents. Everything is stored in local preferences—no Smithery secrets are shipped with the repo.
+
+For deeper integrations—hosting your own MCP servers, enabling OAuth, or wiring Smithery connectors into other runtimes—see [`docs/smithery-mcp.md`](docs/smithery-mcp.md) for a protocol primer and official SDK references.
 
 ## Core Concepts
 
@@ -148,6 +200,8 @@ alBERT uses advanced embedding techniques to understand the meaning of your docu
 ### OpenRouter Integration
 
 alBERT-launcher uses OpenRouter to access powerful language models for enhanced search capabilities:
+
+> **Note:** The app does not include an OpenRouter API key. Provide your own key via the in-app **Settings → Public AI** section or by setting `OPENROUTER_API_KEY` in `.env` before enabling cloud responses.
 
 ```mermaid
 graph TD
@@ -477,6 +531,24 @@ graph TD
    }
    ```
 
+## Open Source Readiness
+
+This repository is set up for collaborative development:
+
+- Environment variables are documented in `.env.example`. Provide your own API keys during local development; none are committed to source control.
+- The renderer and main process read configuration through the validated helpers in `src/main/config.ts`, ensuring secrets never live in the UI bundle.
+- Prefer `npm` for dependency management (`package-lock.json` is authoritative). After cloning, run:
+
+  ```bash
+  npm install
+  npm run dev
+  npm run lint
+  npm run typecheck
+  ```
+
+- Secret scanning is encouraged for contributors (e.g., `git secrets --scan`) before submitting pull requests.
+- UI components follow the frosted-glass design tokens declared in `src/renderer/src/assets/index.css`—please align new work with these utilities for consistency.
+
 3. **Quality Assurance**
    - Automated consistency checks
    - Vector space analysis
@@ -510,38 +582,45 @@ sequenceDiagram
 
 ## Prerequisites
 
-- Node.js (v16 or higher)
-- pnpm package manager
+- Node.js (v18 or higher recommended)
+- npm 9+ (ships with Node.js and matches the repository lockfile)
 - Brave Search API key (optional)
 - OpenRouter API key (optional)
 
 ## Development
 
 ```bash
+# Install dependencies
+npm install
+
 # Start the development server
-pnpm dev
+npm run dev
 ```
 
 ## Building for Production
 
 ```bash
 # For macOS
-pnpm build:mac
+npm run build:mac
 
 # For Windows
-pnpm build:win
+npm run build:win
 
 # For Linux
-pnpm build:linux
+npm run build:linux
 ```
 
 ## Configuration
 
-Create a `.env` file in the root directory with the following variables:
-```env
-BRAVE_API_KEY=your_brave_api_key
-OPENROUTER_API_KEY=your_openrouter_api_key
+Copy `.env.example` to `.env` in the project root and populate any API keys you intend to use:
+
+```bash
+cp .env.example .env
 ```
+
+The application validates its environment variables at startup and will surface an error if required
+values are malformed. Both `BRAVE_API_KEY` and `OPENROUTER_API_KEY` are optional—features that depend on
+them will simply be skipped when the keys are not provided.
 
 ## Project Structure
 

--- a/docs/smithery-mcp.md
+++ b/docs/smithery-mcp.md
@@ -1,0 +1,164 @@
+# Smithery MCP integration playbook
+
+This project ships with first-class support for [Smithery](https://smithery.ai) Model Context Protocol (MCP) connectors so you can blend remote knowledge packs with local search context. Use this guide to wire up additional MCP servers, enable OAuth-backed connectors, or extend alBERT with custom agents.
+
+## Quick start
+
+1. Install the official SDK when building MCP-aware services:
+   ```bash
+   npm install @modelcontextprotocol/sdk
+   ```
+2. Spin up a server using the `McpServer` helper. This example exposes an addition tool and a templated greeting resource:
+   ```ts
+   import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+   import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+   import { z } from "zod";
+
+   const server = new McpServer({
+     name: "my-agent-server",
+     version: "1.0.0",
+   });
+
+   server.registerTool(
+     "add",
+     {
+       title: "Addition Tool",
+       description: "Add two numbers",
+       inputSchema: { a: z.number(), b: z.number() },
+     },
+     async ({ a, b }) => ({
+       content: [{ type: "text", text: String(a + b) }],
+     }),
+   );
+
+   server.registerResource(
+     "greeting",
+     new ResourceTemplate("greeting://{name}", { list: undefined }),
+     {
+       title: "Greeting Resource",
+       description: "Generate dynamic greetings",
+     },
+     async (uri, { name }) => ({
+       contents: [{ uri: uri.href, text: `Hello, ${name}!` }],
+     }),
+   );
+
+   const transport = new StdioServerTransport();
+   await server.connect(transport);
+   ```
+3. Configure the connector inside **Settings → Smithery MCP** using either the public slug (e.g. `spotify`) or a manifest URL. Private connectors require a Smithery API key stored locally via `.env` or the settings panel—never commit credentials to the repository.
+
+## OAuth-enabled connectors
+
+Some MCP servers rely on OAuth to access user accounts. Rather than handling the flow manually, proxy the OAuth lifecycle through Smithery's SDK middleware:
+
+```ts
+import express from "express";
+import { ProxyOAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js";
+import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+
+const app = express();
+
+const proxyProvider = new ProxyOAuthServerProvider({
+  endpoints: {
+    authorizationUrl: "https://auth.external.com/oauth2/v1/authorize",
+    tokenUrl: "https://auth.external.com/oauth2/v1/token",
+    revocationUrl: "https://auth.external.com/oauth2/v1/revoke",
+  },
+  verifyAccessToken: async (token) => ({
+    token,
+    clientId: "123",
+    scopes: ["openid", "email", "profile"],
+  }),
+  getClient: async (client_id) => ({
+    client_id,
+    redirect_uris: ["http://localhost:3000/callback"],
+  }),
+});
+
+app.use(
+  mcpAuthRouter({
+    provider: proxyProvider,
+    issuerUrl: new URL("http://auth.external.com"),
+    baseUrl: new URL("http://mcp.example.com"),
+    serviceDocumentationUrl: new URL("https://docs.example.com/"),
+  }),
+);
+```
+
+With the proxy in place, clients such as LibreChat can complete the full OAuth handshake and refresh cycle automatically:
+
+```yaml
+mcpServers:
+  spotify:
+    type: "streamable-http"
+    initTimeout: 150000
+    url: "https://mcp-spotify-oauth-example.account.workers.dev/mcp"
+```
+
+## Deploying via Streamable HTTP
+
+For production use, prefer the `StreamableHTTPServerTransport` so each client session is isolated and resumable:
+
+```ts
+import express from "express";
+import { randomUUID } from "node:crypto";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+
+const app = express();
+app.use(express.json());
+
+const transports: Record<string, StreamableHTTPServerTransport> = {};
+
+app.post("/mcp", async (req, res) => {
+  const sessionId = req.headers["mcp-session-id"] as string | undefined;
+  let transport = sessionId ? transports[sessionId] : undefined;
+
+  if (!transport && !sessionId && isInitializeRequest(req.body)) {
+    transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (id) => {
+        transports[id] = transport!;
+      },
+    });
+
+    transport.onclose = () => {
+      if (transport?.sessionId) {
+        delete transports[transport.sessionId];
+      }
+    };
+
+    const server = new McpServer({ name: "my-server", version: "1.0.0" });
+    await server.connect(transport);
+  }
+
+  if (!transport) {
+    res.status(400).json({
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Bad Request: No valid session ID provided" },
+      id: null,
+    });
+    return;
+  }
+
+  await transport.handleRequest(req, res, req.body);
+});
+
+app.listen(3000);
+```
+
+## Security & secrets
+
+- The repository includes `.env.example` but ignores `.env`. Store private Smithery API keys or OAuth client secrets locally.
+- Consider running secret scanners such as [`gitleaks`](https://github.com/gitleaks/gitleaks) or GitHub's push protection before publishing forks.
+- The renderer requests MCP content through Smithery's public endpoints. When you host private servers, keep them behind authenticated transports and rotate credentials regularly.
+
+## Additional resources
+
+- [Smithery docs](https://github.com/smithery-ai/docs)
+- [Smithery MCP TypeScript SDK](https://github.com/smithery-ai/mcp-sdk)
+- [Model Context Protocol specification](https://smithery.ai/mcp)
+
+Contributions that extend MCP support—new transports, OAuth providers, or UI workflows—are welcome! Open an issue describing your connector so we can review ergonomics and security implications together.

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -8,6 +8,7 @@ import path from 'node:path'
 import { readContent } from './utils/reader'
 import { embed, rerank } from './embeddings'
 import { SearchResult, CommonSearchResult } from './types'
+import { config } from './config'
 
 interface CacheEntry {
   timestamp: number;
@@ -26,11 +27,15 @@ const t = initTRPC.create({
   isServer: true
 })
 
-const braveSearch = new BraveSearch(process.env.BRAVE_API_KEY || '')
+const braveSearch = new BraveSearch(config.braveApiKey ?? '')
 
-const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || ''
+const OPENROUTER_API_KEY = config.openRouterApiKey ?? ''
 
 async function getPerplexityAnswer(searchTerm: string): Promise<SearchResult | null> {
+  if (!config.hasOpenRouterApiKey) {
+    log.warn('Skipping OpenRouter request because OPENROUTER_API_KEY is not configured')
+    return null
+  }
   try {
     const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
       method: "POST",
@@ -324,6 +329,10 @@ async function searchFiles(searchTerm: string): Promise<SearchResult[]> {
 
 // Update the quickSearchWeb function to handle timeouts and failures
 async function quickSearchWeb(searchTerm: string): Promise<SearchResult[]> {
+  if (!config.hasBraveApiKey) {
+    log.warn('Skipping Brave web search because BRAVE_API_KEY is not configured')
+    return []
+  }
   try {
     // Create a promise that rejects after 1 second
     const timeoutPromise = new Promise((_, reject) => {

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,0 +1,41 @@
+import path from 'node:path'
+import dotenv from 'dotenv'
+import { z } from 'zod'
+
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(['development', 'production', 'test']).optional().default('production'),
+    BRAVE_API_KEY: z.string().trim().min(1).optional(),
+    OPENROUTER_API_KEY: z.string().trim().min(1).optional(),
+    ELECTRON_RENDERER_URL: z.string().trim().url().optional(),
+    VITE_PUBLIC: z.string().trim().optional(),
+    HOME: z.string().trim().optional()
+  })
+  .transform((value) => ({
+    nodeEnv: value.NODE_ENV,
+    braveApiKey: value.BRAVE_API_KEY,
+    openRouterApiKey: value.OPENROUTER_API_KEY,
+    electronRendererUrl: value.ELECTRON_RENDERER_URL,
+    vitePublic: value.VITE_PUBLIC,
+    homeDirectory: value.HOME
+  }))
+
+dotenv.config({ path: process.env.AL_CONFIG_PATH || path.resolve(process.cwd(), '.env') })
+
+const parsedEnv = envSchema.safeParse(process.env)
+
+if (!parsedEnv.success) {
+  const formattedErrors = Object.entries(parsedEnv.error.flatten().fieldErrors)
+    .map(([key, errors]) => `${key}: ${errors?.join(', ')}`)
+    .join('\n')
+  throw new Error(`Invalid environment configuration:\n${formattedErrors}`)
+}
+
+export const config = {
+  ...parsedEnv.data,
+  isDevelopment: parsedEnv.data.nodeEnv === 'development',
+  hasBraveApiKey: Boolean(parsedEnv.data.braveApiKey),
+  hasOpenRouterApiKey: Boolean(parsedEnv.data.openRouterApiKey)
+}
+
+export type AppConfig = typeof config

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,163 +2,133 @@ import {
   app,
   shell,
   BrowserWindow,
-  globalShortcut,
-  screen,
   Tray,
-  Menu,
-  nativeImage
-} from 'electron'
-import { join } from 'node:path'
-import SearchDB from './db'
-import path from 'node:path'
-import { is } from '@electron-toolkit/utils'
-import { createIPCHandler } from 'electron-trpc/main'
-import { getRouter } from './api'
+} from 'electron';
+import path from 'node:path';
+import { destroyTray, createAppTray } from './lifecycle/tray';
+import { createMainWindow } from './lifecycle/window-manager';
+import { registerIpcRouter } from './lifecycle/ipc';
+import { registerToggleShortcut, unregisterAllShortcuts } from './lifecycle/shortcuts';
+import {
+  shutdownSearchDb,
+  startSearchIndexing,
+  persistSearchDb,
+  type IndexingProgressPayload,
+} from './lifecycle/search-service';
+import log from './logger';
 
+process.env.APP_ROOT = path.join(__dirname, '..');
+app.commandLine.appendSwitch('enable-unsafe-webgpu');
 
-// Global variables
-process.env.APP_ROOT = path.join(__dirname, '..')
-let tray: Tray | null = null
-let mainWindow: BrowserWindow | null = null
-app.commandLine.appendSwitch('enable-unsafe-webgpu')
-function createWindow(): void {
-  const currentScreen = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
+let mainWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
 
-  mainWindow = new BrowserWindow({
-    x: currentScreen.bounds.x + (currentScreen.bounds.width - 1200) / 2,
-    y: currentScreen.bounds.y + (currentScreen.bounds.height - 700) / 2,
-    width: 1200,
-    height: 700,
-    alwaysOnTop: true,
-    focusable: true,
-    frame: false,
-    resizable: true,
-    roundedCorners: true,
-    show: false,
-    autoHideMenuBar: true,
-    transparent: true,
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      sandbox: false,
-      nodeIntegration: true,
-      contextIsolation: true,
-      devTools: true
-    }
-  })
+const sendIndexingProgress = (payload: IndexingProgressPayload): void => {
+  mainWindow?.webContents.send('indexing-progress', payload);
+};
 
-  mainWindow.setMinimumSize(600, 400)
-
-  // mainWindow.webContents.openDevTools()
-  // // Set up tRPC handler
-  createIPCHandler({
-    router: getRouter(mainWindow),
-    windows: [mainWindow]
-  })
-
-  mainWindow.on('ready-to-show', () => {
-    mainWindow?.show()
-  })
-
-  if (!is.dev) {
-    mainWindow?.on('blur', () => {
-      mainWindow?.hide()
-    })
+const showMainWindow = (): void => {
+  if (!mainWindow) {
+    return;
   }
 
-  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    mainWindow?.loadURL(process.env['ELECTRON_RENDERER_URL'])
+  if (!mainWindow.isVisible()) {
+    mainWindow.show();
+  }
+  mainWindow.focus();
+};
+
+const hideMainWindow = (): void => {
+  mainWindow?.hide();
+};
+
+const toggleMainWindow = (): void => {
+  if (!mainWindow) {
+    return;
+  }
+
+  if (mainWindow.isVisible()) {
+    hideMainWindow();
   } else {
-    mainWindow?.loadFile(join(__dirname, '../renderer/index.html'))
+    showMainWindow();
+  }
+};
+
+const openAlBERTFolder = (): void => {
+  const albertPath = path.join(app.getPath('home'), 'alBERT');
+  void shell.openPath(albertPath).catch((error) => {
+    log.error('Failed to open alBERT folder', error);
+  });
+};
+
+const initialiseMainWindow = (): void => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    return;
   }
 
-  mainWindow?.on('close', async () => {
-    try {
-      const searchDB = await SearchDB.getInstance(app.getPath('userData'))
-      await searchDB.shutdown()
-    } catch (error) {
-      console.error('Error during shutdown:', error)
-    }
-  })
+  mainWindow = createMainWindow({
+    onClose: () => {
+      void shutdownSearchDb();
+    },
+    onClosed: () => {
+      mainWindow = null;
+    },
+  });
 
-  mainWindow?.on('closed', () => {
-    mainWindow = null
-  })
-}
+  registerIpcRouter(mainWindow);
+  void startSearchIndexing(sendIndexingProgress);
+};
 
-function openAlBERTFolder(): void {
-  const alBERTPath = path.join(app.getPath('home'), 'alBERT')
-  shell.openPath(alBERTPath).catch((error) => {
-    console.error('Failed to open alBERT folder:', error)
-  })
-}
-
-function createTray(): void {
-  const icon = nativeImage.createFromPath(
-    path.join(process.env.VITE_PUBLIC || '', 'electron-vite.svg')
-  )
-  tray = new Tray(icon)
-  const contextMenu = Menu.buildFromTemplate([
-    { label: 'Show', click: () => mainWindow?.show() },
-    { label: 'Open alBERT Folder', click: openAlBERTFolder },
-    { label: 'Quit', click: () => app.quit() }
-  ])
-  tray.setToolTip('Your App Name')
-  tray.setContextMenu(contextMenu)
-}
-
-function toggleWindow(): void {
-  if (mainWindow?.isVisible()) {
-    mainWindow?.hide()
-  } else {
-    mainWindow?.show()
-    mainWindow?.focus()
+const initialiseTray = (): void => {
+  if (tray && !tray.isDestroyed()) {
+    return;
   }
-}
 
-// App lifecycle
-app.whenReady().then(async () => {
-  // Register global shortcut
-  globalShortcut.register('Alt+Space', toggleWindow)
+  tray = createAppTray({
+    onShow: showMainWindow,
+    onOpenFolder: openAlBERTFolder,
+    onQuit: () => app.quit(),
+  });
+};
 
-  // Initialize search database
-  const userDataPath = app.getPath('userData')
-  const searchDB = await SearchDB.getInstance(userDataPath)
-  // Start indexing
-  searchDB
-    .startIndexing(path.join(app.getPath('home'), 'alBERT'), (progress, status) => {
-      mainWindow?.webContents.send('indexing-progress', { progress, status })
-    })
-    .catch((error) => {
-      console.error('Error indexing directory:', error)
-    })
+const bootstrapApplication = (): void => {
+  initialiseMainWindow();
+  initialiseTray();
+  registerToggleShortcut('Alt+Space', toggleMainWindow);
+};
 
-  createWindow()
-  createTray()
+app.whenReady().then(() => {
+  try {
+    bootstrapApplication();
+  } catch (error) {
+    log.error('Failed to bootstrap application', error);
+  }
+
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
-})
+    if (BrowserWindow.getAllWindows().length === 0) {
+      initialiseMainWindow();
+    }
+    showMainWindow();
+  });
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});
 
-app.on('will-quit', async () => {
-  // Clean up
-  globalShortcut.unregisterAll()
+app.on('will-quit', () => {
+  unregisterAllShortcuts();
+  void persistSearchDb();
+  void shutdownSearchDb();
+  destroyTray(tray);
+  tray = null;
+});
 
-  // Persist search database
-  const userDataPath = app.getPath('userData')
-  const searchDB = await SearchDB.getInstance(userDataPath)
-  await searchDB.persist()
-})
-
-// Handle external links
 app.on('web-contents-created', (_, contents) => {
   contents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url)
-    return { action: 'deny' }
-  })
-})
+    void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+});

--- a/src/main/lifecycle/ipc.ts
+++ b/src/main/lifecycle/ipc.ts
@@ -1,0 +1,10 @@
+import type { BrowserWindow } from 'electron';
+import { createIPCHandler } from 'electron-trpc/main';
+import { getRouter } from '../api';
+
+export const registerIpcRouter = (window: BrowserWindow): void => {
+  createIPCHandler({
+    router: getRouter(window),
+    windows: [window],
+  });
+};

--- a/src/main/lifecycle/search-service.ts
+++ b/src/main/lifecycle/search-service.ts
@@ -1,0 +1,75 @@
+import { app } from 'electron';
+import path from 'node:path';
+import type SearchDB from '../db';
+import log from '../logger';
+
+export interface IndexingProgressPayload {
+  progress: number;
+  status: string;
+}
+
+export type IndexingProgressHandler = (payload: IndexingProgressPayload) => void;
+
+let searchDbInstance: SearchDB | null = null;
+let searchDbPromise: Promise<SearchDB> | null = null;
+
+const resolveSearchDb = async (): Promise<SearchDB> => {
+  if (searchDbInstance) {
+    return searchDbInstance;
+  }
+
+  if (!searchDbPromise) {
+    const userDataPath = app.getPath('userData');
+    searchDbPromise = import('../db').then(async ({ default: SearchDBModule }) => {
+      const instance = await SearchDBModule.getInstance(userDataPath);
+      searchDbInstance = instance;
+      return instance;
+    });
+  }
+
+  return searchDbPromise;
+};
+
+export const startSearchIndexing = async (
+  onProgress?: IndexingProgressHandler,
+): Promise<void> => {
+  try {
+    const searchDb = await resolveSearchDb();
+    const albertDirectory = path.join(app.getPath('home'), 'alBERT');
+
+    await searchDb.startIndexing(albertDirectory, (progress, status) => {
+      onProgress?.({ progress, status });
+    });
+  } catch (error) {
+    log.error('Error indexing directory', error);
+  }
+};
+
+const getCurrentInstance = (): SearchDB | null => searchDbInstance;
+
+export const persistSearchDb = async (): Promise<void> => {
+  try {
+    const instance = getCurrentInstance();
+    if (!instance) {
+      return;
+    }
+    await instance.persist();
+  } catch (error) {
+    log.error('Error while persisting search database', error);
+  }
+};
+
+export const shutdownSearchDb = async (): Promise<void> => {
+  try {
+    const instance = getCurrentInstance();
+    if (!instance) {
+      return;
+    }
+    await instance.shutdown();
+  } catch (error) {
+    log.error('Error during search database shutdown', error);
+  } finally {
+    searchDbInstance = null;
+    searchDbPromise = null;
+  }
+};

--- a/src/main/lifecycle/shortcuts.ts
+++ b/src/main/lifecycle/shortcuts.ts
@@ -1,0 +1,19 @@
+import { globalShortcut } from 'electron';
+import log from '../logger';
+
+export type ShortcutHandler = () => void;
+
+export const registerToggleShortcut = (
+  accelerator: string,
+  handler: ShortcutHandler,
+): void => {
+  const success = globalShortcut.register(accelerator, handler);
+
+  if (!success) {
+    log.error(`Failed to register global shortcut: ${accelerator}`);
+  }
+};
+
+export const unregisterAllShortcuts = (): void => {
+  globalShortcut.unregisterAll();
+};

--- a/src/main/lifecycle/tray.ts
+++ b/src/main/lifecycle/tray.ts
@@ -1,0 +1,40 @@
+import { Menu, Tray, nativeImage } from 'electron';
+import path from 'node:path';
+import { config } from '../config';
+
+export interface CreateTrayOptions {
+  onShow: () => void;
+  onOpenFolder: () => void;
+  onQuit: () => void;
+  tooltip?: string;
+  iconPath?: string;
+}
+
+export const createAppTray = ({
+  onShow,
+  onOpenFolder,
+  onQuit,
+  tooltip = 'alBERT Launcher',
+  iconPath,
+}: CreateTrayOptions): Tray => {
+  const resolvedIconPath = iconPath ?? path.join(config.vitePublic ?? '', 'electron-vite.svg');
+  const icon = nativeImage.createFromPath(resolvedIconPath);
+  const tray = new Tray(icon);
+
+  const contextMenu = Menu.buildFromTemplate([
+    { label: 'Show', click: onShow },
+    { label: 'Open alBERT Folder', click: onOpenFolder },
+    { label: 'Quit', click: onQuit },
+  ]);
+
+  tray.setToolTip(tooltip);
+  tray.setContextMenu(contextMenu);
+
+  return tray;
+};
+
+export const destroyTray = (tray: Tray | null): void => {
+  if (tray && !tray.isDestroyed()) {
+    tray.destroy();
+  }
+};

--- a/src/main/lifecycle/window-manager.ts
+++ b/src/main/lifecycle/window-manager.ts
@@ -1,0 +1,85 @@
+import { BrowserWindow, type BrowserWindowConstructorOptions, screen } from 'electron';
+import { join } from 'node:path';
+import { is } from '@electron-toolkit/utils';
+import { config } from '../config';
+
+const DEFAULT_WINDOW_DIMENSIONS = {
+  width: 1200,
+  height: 700,
+  minWidth: 600,
+  minHeight: 400,
+};
+
+export interface CreateMainWindowOptions {
+  /** Triggered once the window is ready to be presented. */
+  onReadyToShow?: (window: BrowserWindow) => void;
+  /** Triggered whenever the window blurs in production builds. */
+  onBlur?: (window: BrowserWindow) => void;
+  /** Triggered when the window is closing. */
+  onClose?: (window: BrowserWindow) => void;
+  /** Triggered after the window has been closed and destroyed. */
+  onClosed?: () => void;
+}
+
+const buildWindowOptions = (): BrowserWindowConstructorOptions => {
+  const currentScreen = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+
+  return {
+    x: currentScreen.bounds.x + (currentScreen.bounds.width - DEFAULT_WINDOW_DIMENSIONS.width) / 2,
+    y: currentScreen.bounds.y + (currentScreen.bounds.height - DEFAULT_WINDOW_DIMENSIONS.height) / 2,
+    width: DEFAULT_WINDOW_DIMENSIONS.width,
+    height: DEFAULT_WINDOW_DIMENSIONS.height,
+    alwaysOnTop: true,
+    focusable: true,
+    frame: false,
+    resizable: true,
+    roundedCorners: true,
+    show: false,
+    autoHideMenuBar: true,
+    transparent: true,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      sandbox: false,
+      nodeIntegration: true,
+      contextIsolation: true,
+      devTools: true,
+    },
+  };
+};
+
+export const createMainWindow = (options: CreateMainWindowOptions = {}): BrowserWindow => {
+  const window = new BrowserWindow(buildWindowOptions());
+
+  window.setMinimumSize(DEFAULT_WINDOW_DIMENSIONS.minWidth, DEFAULT_WINDOW_DIMENSIONS.minHeight);
+
+  window.once('ready-to-show', () => {
+    options.onReadyToShow?.(window);
+    window.show();
+  });
+
+  if (!is.dev) {
+    window.on('blur', () => {
+      if (options.onBlur) {
+        options.onBlur(window);
+      } else {
+        window.hide();
+      }
+    });
+  }
+
+  window.on('close', () => {
+    options.onClose?.(window);
+  });
+
+  window.on('closed', () => {
+    options.onClosed?.();
+  });
+
+  if (is.dev && config.electronRendererUrl) {
+    void window.loadURL(config.electronRendererUrl);
+  } else {
+    void window.loadFile(join(__dirname, '../renderer/index.html'));
+  }
+
+  return window;
+};

--- a/src/main/utils/logger.ts
+++ b/src/main/utils/logger.ts
@@ -1,14 +1,17 @@
-import log from 'electron-log';
-import path from 'path';
+import log from 'electron-log'
+import path from 'node:path'
+import { config } from '../config'
 
 // Configure electron-log
-log.transports.file.resolvePathFn = () => path.join(process.env.HOME || '', 'alBERT', 'userData', 'logs', 'main.log');
-log.transports.file.maxSize = 1024 * 1024 * 10; // 10MB
-log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
+log.transports.file.resolvePathFn = () =>
+  path.join(config.homeDirectory ?? '', 'alBERT', 'userData', 'logs', 'main.log')
+log.transports.file.maxSize = 1024 * 1024 * 10 // 10MB
+log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}'
 
 // Also log to console in development
-if (process.env.NODE_ENV === 'development') {
-  log.transports.console.level = 'debug';
+if (config.isDevelopment) {
+  log.transports.console.level = 'debug'
 }
 
-export const logger = log;
+export const logger = log
+export default log

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,7 +8,9 @@ import React, {
   useReducer,
 } from 'react';
 import { Card, CardContent, CardHeader, CardFooter } from '@/components/ui/card';
-import { getContextSimilarityScores, trpcClient } from './util/trpc-client';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { trpcClient } from './util/trpc-client';
 import { cn, debounce } from '@/lib/utils';
 import SearchBar from '@/components/SearchBar';
 import SearchResults from '@/components/SearchResults';
@@ -21,15 +23,28 @@ import {
 } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createContextMiddleware } from './lib/context-middleware';
-import { LLMSettings, ContextTab } from './types';
+import {
+  LLMSettings,
+  ContextTab,
+  SmitheryMCPServer,
+  SmitheryContextResult,
+  Source,
+  AIResponse,
+} from './types';
 import type { SearchBarRef } from '@/components/SearchBar';
-import { getRankedChunks, RankedChunk } from '@/lib/context-utils';
+import type {
+  CachedSearch,
+  PanelState,
+  SearchResult,
+  SearchState,
+  StickyNote,
+} from './types/search';
 const ResponsePanel = React.lazy(() => import('@/components/ResponsePanel'));
 import SearchBadges, { SearchStep } from '@/components/SearchBadges';
 import { v4 as uuidv4 } from 'uuid';
 import { AnimatePresence } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
-import { Globe, FileText, X } from 'lucide-react';
+import { Globe, FileText, X, Sparkles, StickyNote, Library, Settings2, RadioTower } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -51,67 +66,16 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-
-interface SearchResult {
-  text: string;
-  dist: {
-    corpus_id: number;
-    score: number;
-    text: string;
-  };
-  metadata: {
-    path: string;
-    title?: string;
-    created_at: number;
-    modified_at: number;
-    filetype: string;
-    languages: string[];
-    links: string[];
-    owner: string | null;
-    seen_at: number;
-    sourceType?: 'document' | 'web';
-  };
-  queryContext?: {
-    query: string;
-    subQueries?: Array<{
-      query: string;
-      answer: string;
-    }>;
-  };
-}
-
-interface AIResponse {
-  question: string;
-  answer: string;
-  timestamp: number;
-  sources?: Source[];
-}
-
-// Add a new type for panel states
-type PanelState = 'none' | 'settings' | 'response' | 'document' | 'chat';
-
-// Add this interface near the top with other interfaces
-interface Source {
-  path: string;
-  preview?: string;
-  citations?: string[];
-  description?: string;
-}
-
-// Add this interface near the top
-interface CachedSearch {
-  query: string;
-  results: SearchResult[];
-  timestamp: number;
-}
-
-// Add these types near the top with other interfaces
-type SearchState =
-  | { status: 'idle' }
-  | { status: 'searching'; query: string; shouldChat?: boolean }
-  | { status: 'searched'; query: string; results: SearchResult[] }
-  | { status: 'chatting'; query: string; results: SearchResult[] }
-  | { status: 'error'; error: string };
+import { usePersistentState } from './hooks/usePersistentState';
+import {
+  createDefaultPrivateSettings,
+  createDefaultPublicSettings,
+} from './lib/default-settings';
+import SmitheryContextResults from '@/components/SmitheryContextResults';
+import { createSmitheryServerFromInput } from './lib/smithery';
+import { useSmitheryContext } from './hooks/useSmitheryContext';
+import { useContextScoring } from './hooks/useContextScoring';
+import { buildCombinedContext } from './lib/context-builder';
 
 // Add this reducer function before the App component
 function searchReducer(
@@ -169,7 +133,8 @@ const truncateText = (text: string, maxLength: number = 150): string => {
 const DropArea: React.FC<{
   children: React.ReactNode;
   onDrop: (item: any, position: { x: number; y: number }) => void;
-}> = ({ children, onDrop }) => {
+  className?: string;
+}> = ({ children, onDrop, className }) => {
   const [, drop] = useDrop({
     accept: 'searchResult',
     drop: (item: any, monitor) => {
@@ -181,11 +146,14 @@ const DropArea: React.FC<{
   });
 
   return (
-    <div ref={drop} className="h-screen w-screen">
+    <div ref={drop} className={cn('relative min-h-screen w-full overflow-hidden', className)}>
       {children}
     </div>
   );
 };
+
+const PANEL_BASE_CLASS =
+  'glass-panel relative flex w-full flex-col overflow-hidden rounded-[32px] border border-white/10 shadow-[0_40px_140px_-70px_rgba(15,23,42,0.85)] transition-all duration-300 hover:border-white/20';
 
 function App(): JSX.Element {
   // State Definitions
@@ -194,121 +162,88 @@ function App(): JSX.Element {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [isPrivate, setIsPrivate] = useState<boolean>(() => {
-    const savedPrivacy = localStorage.getItem('llm-privacy');
-    return savedPrivacy ? JSON.parse(savedPrivacy) : false;
-  });
+  const [isPrivate, setIsPrivate] = usePersistentState<boolean>('llm-privacy', false);
   const [stickyNotes, setStickyNotes] = useState<StickyNote[]>([]);
 
-  const [useAgent, setUseAgent] = useState<boolean>(() => {
-    const savedAgentPref = localStorage.getItem('use-agent');
-    return savedAgentPref ? JSON.parse(savedAgentPref) : true;
-  });
+  const [useAgent, setUseAgent] = usePersistentState<boolean>('use-agent', true);
 
-  const [privateSettings, setPrivateSettings] = useState<LLMSettings>(() => {
-    const saved = localStorage.getItem('llm-settings-private');
-    return saved
-      ? JSON.parse(saved)
-      : {
-          baseUrl: 'http://localhost:11434/v1',
-          apiKey: '',
-          model: 'llama3.2:3b',
-          modelType: 'ollama',
-        };
-  });
+  const [privateSettings, setPrivateSettings] = usePersistentState<LLMSettings>(
+    'llm-settings-private',
+    createDefaultPrivateSettings
+  );
 
-  const [publicSettings, setPublicSettings] = useState<LLMSettings>(() => {
-    const saved = localStorage.getItem('llm-settings-public');
-    return saved
-      ? JSON.parse(saved)
-      : {
-          baseUrl: 'https://openrouter.ai/api/v1',
-          apiKey:
-            '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',
-          model: 'openai/gpt-4o-mini',
-          modelType: 'openai',
-        };
-  });
+  const [publicSettings, setPublicSettings] = usePersistentState<LLMSettings>(
+    'llm-settings-public',
+    createDefaultPublicSettings
+  );
+
+  const [smitheryApiKey, setSmitheryApiKey] = usePersistentState<string>('smithery-api-key', '');
+  const [smitheryServers, setSmitheryServers] = usePersistentState<SmitheryMCPServer[]>(
+    'smithery-servers',
+    () => []
+  );
+  const [smitheryManualError, setSmitheryManualError] = useState<string | null>(null);
 
   const currentSettings = useMemo(
     () => (isPrivate ? privateSettings : publicSettings),
     [isPrivate, privateSettings, publicSettings]
   );
 
-  const provider =
-    currentSettings.modelType === 'openai'
-      ? createOpenAI({
-          apiKey: currentSettings.apiKey,
-          baseUrl: currentSettings.baseUrl,
-        })
-      : createOpenAI({
-          apiKey: currentSettings.apiKey,
-          baseUrl: 'http://localhost:11434/v1',
-        });
+  const activeSmitheryServers = useMemo(
+    () => smitheryServers.filter((server) => server.enabled !== false),
+    [smitheryServers]
+  );
+
+  const {
+    results: smitheryResults,
+    isLoading: isSmitheryLoading,
+    error: smitheryContextError,
+    refresh: refreshSmitheryContext,
+  } = useSmitheryContext({
+    query,
+    servers: smitheryServers,
+    apiKey: smitheryApiKey || undefined,
+    enabled: activeSmitheryServers.length > 0,
+  });
+
+  const smitheryError = smitheryContextError ?? smitheryManualError;
+
+  const provider = useMemo(() => {
+    if (currentSettings.modelType === 'openai') {
+      return createOpenAI({
+        apiKey: currentSettings.apiKey,
+        baseUrl: currentSettings.baseUrl,
+      });
+    }
+
+    return createOpenAI({
+      apiKey: currentSettings.apiKey,
+      baseUrl: currentSettings.baseUrl || 'http://localhost:11434/v1',
+    });
+  }, [currentSettings]);
 
   const [conversations, setConversations] = useState<AIResponse[]>([]);
 
-  // Add this utility function near the top
-  const combinedSearchContext = useMemo(() => {
-    const MAX_CONTEXT_LENGTH = 50000;
-    let context = '';
-
-    try {
-      // First, add all sticky notes to context as they are prioritized
-      const stickyContext = stickyNotes
-        .map((note) => {
-          const relevanceNote = ' (pinned)';
-          return `\n\nFrom ${note.metadata.path}${relevanceNote}:\n${note.text}`;
-        })
-        .join('');
-
-      // Get search results for scoring
-      const searchDocuments = searchResults.map((result) => ({
-        content: result.text,
-        path: result.metadata.path,
-        type: result.metadata.sourceType === 'web' ? 'web' : 'document',
-      }));
-
-      // Select search documents up to remaining length
-      let currentLength = stickyContext.length;
-      const selectedSearchDocs = searchDocuments.filter((doc) => {
-        const length = doc.content.length;
-        if (currentLength + length <= MAX_CONTEXT_LENGTH) {
-          currentLength += length;
-          return true;
-        }
-        return false;
-      });
-
-      // Build context with sticky notes first, then search results
-      context = stickyContext; // Start with sticky notes
-
-      // Add search results if there's space
-      if (selectedSearchDocs.length > 0) {
-        const searchContext = selectedSearchDocs
-          .map((doc) => `\n\nFrom ${doc.path}:\n${doc.content}`)
-          .join('');
-
-        context += searchContext;
-      }
-
-      return context.trim();
-    } catch (error) {
-      console.error('Error building context:', error);
-      return '';
-    }
-  }, [query, searchResults, stickyNotes]);
+  const combinedSearchContext = useMemo(
+    () =>
+      buildCombinedContext({
+        stickyNotes,
+        smitheryResults,
+        searchResults,
+      }),
+    [searchResults, smitheryResults, stickyNotes]
+  );
 
   // Update the activePanel state to use the new type
   const [activePanel, setActivePanel] = useState<PanelState>('response');
+  const toggleSettingsPanel = useCallback(() => {
+    setActivePanel((prev) => (prev === 'settings' ? 'response' : 'settings'));
+  }, []);
 
   const searchBarRef = useRef<SearchBarRef>(null);
 
   // Add this near your other state definitions
   const searchTimeoutRef = useRef<NodeJS.Timeout>();
-
-  // Add to state definitions
-  const [rankedChunks, setRankedChunks] = useState<RankedChunk[]>([]);
 
   // Add cache state
   const [searchCache, setSearchCache] = useState<CachedSearch[]>([]);
@@ -329,73 +264,11 @@ function App(): JSX.Element {
     [searchCache]
   );
 
-  // Add effect to handle reranking
-  useEffect(() => {
-    const updateRankedChunks = async (): Promise<void> => {
-      const documents = [
-        ...searchResults.map((result) => ({
-          content: result.text,
-          path: result.metadata.path,
-          type: result.metadata.sourceType === 'web' ? 'web' : 'document',
-        })),
-      ];
-
-      const chunks = await getRankedChunks({
-        query,
-        documents,
-        chunkSize: 500,
-        minScore: 0.1,
-      });
-
-      setRankedChunks(chunks);
-    };
-
-    if (query && searchResults.length > 0) {
-      updateRankedChunks();
-    } else {
-      setRankedChunks([]);
-    }
-  }, [query, searchResults]);
-
-  // Add a separate effect to update similarity scores
-  const [documentScores, setDocumentScores] = useState<Map<string, number>>(
-    new Map()
-  );
-
-  useEffect(() => {
-    const updateSimilarityScores = async () => {
-      const documents = [
-        ...searchResults.map((result) => ({
-          content: result.text,
-          path: result.metadata.path,
-          type: result.metadata.sourceType === 'web' ? 'web' : 'document',
-        })),
-      ];
-
-      if (documents.length === 0) return;
-
-      try {
-        const similarityScores = await getContextSimilarityScores(
-          [query],
-          documents
-        );
-
-        const scoreMap = new Map<string, number>();
-        similarityScores.forEach((doc) => {
-          const score = doc.scores[0];
-          scoreMap.set(doc.path, score);
-        });
-
-        setDocumentScores(scoreMap);
-      } catch (error) {
-        console.error('Error calculating similarity scores:', error);
-      }
-    };
-
-    if (query) {
-      updateSimilarityScores();
-    }
-  }, [query, searchResults]);
+  const { rankedChunks, documentScores } = useContextScoring({
+    query,
+    searchResults,
+    smitheryResults,
+  });
 
   // Update generateChatResponse to include full agent logic
   const generateChatResponse = useCallback(
@@ -580,6 +453,38 @@ Keep your response focused and concise.`,
   // Update askAIQuestion to properly handle both agent and non-agent paths
   const askAIQuestion = useCallback(
     async (originalQuery: string) => {
+      if (currentSettings.modelType === 'openai' && !currentSettings.apiKey.trim()) {
+        setSearchSteps((prev) => {
+          const alreadyWarned = prev.some(
+            (step) => step.query === 'Add an OpenRouter API key in Settings to chat.'
+          );
+          if (alreadyWarned) {
+            return prev;
+          }
+
+          return [
+            ...prev,
+            {
+              id: uuidv4(),
+              query: 'Add an OpenRouter API key in Settings to chat.',
+              status: 'failed',
+            },
+          ];
+        });
+
+        setConversations((prev) => [
+          ...prev,
+          {
+            question: originalQuery,
+            answer:
+              'Add an OpenRouter API key in Settings to enable cloud responses, or switch to a private model.',
+            timestamp: Date.now(),
+            sources: [],
+          },
+        ]);
+        return;
+      }
+
       const baseModel = provider(currentSettings.model);
       const contextMiddleware = createContextMiddleware({
         getContext: () => combinedSearchContext,
@@ -697,7 +602,7 @@ Keep your response focused and concise.`,
           {
             id: uuidv4(),
             query: 'Error occurred during processing',
-            status: 'error',
+            status: 'failed',
           },
         ]);
       }
@@ -830,6 +735,33 @@ Keep your response focused and concise.`,
     [debouncedSearch]
   );
 
+  const refreshSmitheryServer = useCallback(
+    async (server: SmitheryMCPServer) => {
+      setSmitheryManualError(null);
+      try {
+        const refreshed = await createSmitheryServerFromInput(
+          server.manifestUrl ?? server.slug,
+          {
+            apiKey: smitheryApiKey || undefined,
+            existing: server,
+          }
+        );
+
+        setSmitheryServers((prev) =>
+          prev.map((entry) =>
+            entry.id === server.id ? { ...refreshed, enabled: entry.enabled } : entry
+          )
+        );
+      } catch (error) {
+        console.error('Failed to refresh Smithery connector from dashboard', error);
+        setSmitheryManualError((prev) =>
+          prev ?? 'Failed to refresh Smithery connector metadata.'
+        );
+      }
+    },
+    [setSmitheryServers, smitheryApiKey]
+  );
+
   // Add cleanup effect
   useEffect(() => {
     return (): void => {
@@ -939,13 +871,6 @@ Keep your response focused and concise.`,
     }
   }, [searchState]);
 
-  // Add new interfaces
-  interface StickyNote extends SearchResult {
-    id: string;
-    position: { x: number; y: number };
-    isDragging?: boolean;
-  }
-
   // Add clearChat function
   const clearChat = useCallback(() => {
     setConversations([]);
@@ -957,43 +882,67 @@ Keep your response focused and concise.`,
   }, []);
 
   // Add this new function to handle creating sticky notes
-  const createStickyNote = (
-    result: SearchResult | { text: string; metadata: any },
-    position: { x: number; y: number }
-  ): void => {
-    const newNote: StickyNote = {
-      ...result,
-      id: uuidv4(),
-      position,
-      isDragging: false,
-      dist:
-        'dist' in result
-          ? result.dist
-          : { corpus_id: 0, score: 1, text: result.text },
-    };
-    setStickyNotes((prev) => [...prev, newNote]);
+  const createStickyNote = useCallback(
+    (
+      result: SearchResult | { text: string; metadata: any },
+      position: { x: number; y: number }
+    ): void => {
+      const newNote: StickyNote = {
+        ...result,
+        id: uuidv4(),
+        position,
+        isDragging: false,
+        dist:
+          'dist' in result
+            ? result.dist
+            : { corpus_id: 0, score: 1, text: result.text },
+      };
+      setStickyNotes((prev) => [...prev, newNote]);
 
-    // Only remove from search results if it's a SearchResult
-    if ('dist' in result) {
-      setSearchResults((prev) =>
-        prev.filter((item) => item.metadata.path !== result.metadata.path)
-      );
-    }
-  };
+      // Only remove from search results if it's a SearchResult
+      if ('dist' in result) {
+        setSearchResults((prev) =>
+          prev.filter((item) => item.metadata.path !== result.metadata.path)
+        );
+      }
+    },
+    []
+  );
+
+  const spawnQuickNote = useCallback(() => {
+    createStickyNote(
+      {
+        text: '# New Note\n\nCapture your ideas…',
+        metadata: {
+          path: `note-${Date.now()}.md`,
+          created_at: Date.now() / 1000,
+          modified_at: Date.now() / 1000,
+          filetype: 'markdown',
+          languages: ['en'],
+          links: [],
+          owner: null,
+          seen_at: Date.now() / 1000,
+          sourceType: 'document',
+        },
+      },
+      {
+        x: window.innerWidth / 2 - 200,
+        y: window.innerHeight / 2 - 200,
+      }
+    );
+  }, [createStickyNote]);
 
   // Add drag handling functions using React DnD
 
   // Add to existing imports
-  const [showOnboarding, setShowOnboarding] = useState(() => {
-    const hasCompletedOnboarding = localStorage.getItem('onboarding-completed');
-    return !hasCompletedOnboarding;
-  });
+  const [hasCompletedOnboarding, setHasCompletedOnboarding] =
+    usePersistentState<boolean>('onboarding-completed', false);
+  const showOnboarding = !hasCompletedOnboarding;
 
   // Add this function near other utility functions
-  const handleOnboardingComplete = () => {
-    localStorage.setItem('onboarding-completed', 'true');
-    setShowOnboarding(false);
-  };
+  const handleOnboardingComplete = useCallback(() => {
+    setHasCompletedOnboarding(true);
+  }, [setHasCompletedOnboarding]);
 
   // Update the filterOutStickyNotes function
   const filterOutStickyNotes = (results: SearchResult[]): SearchResult[] => {
@@ -1138,26 +1087,7 @@ Keep your response focused and concise.`,
       // Handle Cmd/Ctrl + N for new note
       if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
         e.preventDefault();
-        createStickyNote(
-          {
-            text: '# New Note\n\nStart typing here...',
-            metadata: {
-              path: `note-${Date.now()}.md`,
-              created_at: Date.now() / 1000,
-              modified_at: Date.now() / 1000,
-              filetype: 'markdown',
-              languages: ['en'],
-              links: [],
-              owner: null,
-              seen_at: Date.now() / 1000,
-              sourceType: 'document',
-            },
-          },
-          {
-            x: window.innerWidth / 2 - 200,
-            y: window.innerHeight / 2 - 200,
-          }
-        );
+        spawnQuickNote();
         return;
       }
     },
@@ -1175,7 +1105,7 @@ Keep your response focused and concise.`,
       useAgent,
       openAlBERTFolder,
       copyToClipboard,
-      createStickyNote,
+      spawnQuickNote,
       clearChat,
     ]
   );
@@ -1293,7 +1223,7 @@ Keep your response focused and concise.`,
         }}
         className="group"
       >
-        <Card className="w-96 shadow-lg bg-background/95 backdrop-blur-sm border-muted">
+        <Card className="glass-panel w-96 border-white/15 bg-slate-950/80 text-slate-100 shadow-[0_32px_120px_-70px_rgba(15,23,42,0.9)]">
           {/* Header */}
           <CardHeader className="p-3 pb-2">
             <div className="flex items-center justify-between">
@@ -1370,51 +1300,151 @@ Keep your response focused and concise.`,
     );
   };
 
+  const shouldShowResponsePanel =
+    conversations.length > 0 && activePanel === 'response';
+  const isSettingsActive = activePanel === 'settings';
+  const modeBadgeLabel = isPrivate ? 'Private workspace' : 'Open web mode';
+  const modeDescription = useAgent ? 'Agentic research' : 'Direct search';
+  const connectorSummary = useMemo(() => {
+    if (activeSmitheryServers.length === 0) {
+      return 'Link MCPs';
+    }
+
+    if (activeSmitheryServers.length === 1) {
+      return '1 MCP linked';
+    }
+
+    return `${activeSmitheryServers.length} MCPs linked`;
+  }, [activeSmitheryServers.length]);
+  const stats: Array<{ label: string; value: number; icon: React.ElementType }> = [
+    { label: 'Pinned notes', value: stickyNotes.length, icon: StickyNote },
+    { label: 'Results surfaced', value: searchResults.length + smitheryResults.length, icon: Library },
+    { label: 'Conversations', value: conversations.length, icon: Sparkles },
+    { label: 'MCP connectors', value: activeSmitheryServers.length, icon: RadioTower },
+  ];
+
   // Update the return statement to include Onboarding
   return (
     <DndProvider backend={HTML5Backend}>
-      <DropArea onDrop={(item, position) => {
-        if (item.type === 'searchResult') {
-          createStickyNote(item.result, position);
-        }
-      }}>
-        <div className="h-screen w-screen flex items-center justify-center">
-          {/* Add Onboarding at the top level */}
-          {showOnboarding && <Onboarding onComplete={handleOnboardingComplete} />}
+      <DropArea
+        onDrop={(item, position) => {
+          if (item.type === 'searchResult') {
+            createStickyNote(item.result, position);
+          }
+        }}
+        className="overflow-hidden text-slate-100"
+      >
+        <div className="glass-grid absolute inset-0 z-0 opacity-60" />
+        <div className="pointer-events-none absolute inset-0 z-0">
+          <div className="animate-float-slow absolute -left-40 -top-48 h-[32rem] w-[32rem] rounded-full bg-gradient-to-br from-sky-500/30 via-cyan-400/20 to-transparent blur-[140px]" />
+          <div className="animate-float-medium absolute bottom-[-16rem] right-[-12rem] h-[30rem] w-[30rem] rounded-full bg-gradient-to-br from-fuchsia-500/25 via-indigo-400/20 to-transparent blur-[140px]" />
+        </div>
 
-          <div className="flex flex-col" data-highlight="search-container">
-            <div className="flex gap-4 transition-all duration-200">
-              {/* Settings Panel */}
-              {activePanel === 'settings' && (
-                <Suspense fallback={<div>Loading Settings...</div>}>
-                  <Card
-                    className="bg-background/95 shadow-2xl flex flex-col transition-all duration-200 rounded-xl overflow-hidden"
-                    style={{ width: 600 }}
-                  >
-                    <CardContent className="p-4 flex flex-col h-[600px]">
-                      <SettingsPanel
-                        isPrivate={isPrivate}
-                        setIsPrivate={setIsPrivate}
-                        privateSettings={privateSettings}
-                        publicSettings={publicSettings}
-                        setPrivateSettings={setPrivateSettings}
-                        setPublicSettings={setPublicSettings}
-                        setActivePanel={setActivePanel}
-                      />
-                    </CardContent>
-                  </Card>
-                </Suspense>
+        {showOnboarding && <Onboarding onComplete={handleOnboardingComplete} />}
+
+        <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-10 px-6 py-10 lg:px-12">
+          <header className="glass-panel overflow-hidden rounded-[40px] border border-white/10 px-8 py-10 shadow-[0_40px_140px_-80px_rgba(37,99,235,0.45)]">
+            <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
+              <div className="space-y-5">
+                <span className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.35em] text-slate-300/70">
+                  <Sparkles className="h-3.5 w-3.5 text-sky-200" />
+                  Liquid glass workspace
+                </span>
+                <h1 className="text-3xl font-semibold text-white md:text-4xl">
+                  Research, curate, and brief with clarity.
+                </h1>
+                <p className="max-w-2xl text-sm text-slate-300/80">
+                  Blend semantic search, contextual chat, and floating notes in a translucent environment inspired by the newest macOS and iOS design language.
+                </p>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Badge className="rounded-full border border-white/25 bg-white/10 px-4 py-1 text-[11px] uppercase tracking-[0.22em] text-slate-100/85">
+                    {modeBadgeLabel}
+                  </Badge>
+                  <Badge className="rounded-full border border-white/20 bg-white/10 px-4 py-1.5 text-[11px] uppercase tracking-[0.28em] text-slate-100/85">
+                    {modeDescription}
+                  </Badge>
+                  <Badge className="flex items-center gap-2 rounded-full border border-white/15 bg-sky-400/15 px-4 py-1.5 text-[11px] uppercase tracking-[0.28em] text-sky-100">
+                    <RadioTower className="h-3.5 w-3.5" />
+                    {activeSmitheryServers.length > 0
+                      ? `${activeSmitheryServers.length} MCP${
+                          activeSmitheryServers.length > 1 ? 's' : ''
+                        }`
+                      : 'Link MCPs'}
+                  </Badge>
+                </div>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <Button
+                  variant="ghost"
+                  onClick={spawnQuickNote}
+                  className="h-auto rounded-2xl border border-white/25 bg-white/10 px-5 py-4 text-sm font-semibold text-white shadow-[0_24px_80px_-60px_rgba(59,130,246,0.55)] transition hover:border-white/40 hover:bg-white/20"
+                >
+                  <StickyNote className="h-4 w-4" />
+                  Capture note
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={toggleSettingsPanel}
+                  className="h-auto rounded-2xl border border-white/20 bg-white/5 px-5 py-4 text-sm font-medium text-slate-100/85 transition hover:border-white/35 hover:bg-white/12"
+                >
+                  <Settings2 className="h-4 w-4" />
+                  {isSettingsActive ? 'Hide settings' : 'Workspace settings'}
+                </Button>
+              </div>
+            </div>
+            <div className="mt-10 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {stats.map(({ label, value, icon: Icon }) => (
+                <div
+                  key={label}
+                  className="flex flex-col gap-3 rounded-[26px] border border-white/12 bg-white/8 px-5 py-4 backdrop-blur-2xl"
+                >
+                  <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-slate-300/75">
+                    <Icon className="h-4 w-4 text-sky-200" />
+                    {label}
+                  </div>
+                  <span className="text-2xl font-semibold text-white">{value}</span>
+                </div>
+              ))}
+            </div>
+          </header>
+
+          <div
+            className="flex flex-col gap-6 transition-all duration-300 xl:flex-row xl:items-start xl:justify-center"
+            data-highlight="search-container"
+          >
+            {isSettingsActive && (
+              <Suspense fallback={<div>Loading Settings...</div>}>
+                <Card className={cn(PANEL_BASE_CLASS, 'w-full max-w-xl')}>
+                  <CardContent className="flex h-[600px] flex-col p-6">
+                    <SettingsPanel
+                      isPrivate={isPrivate}
+                      setIsPrivate={setIsPrivate}
+                      privateSettings={privateSettings}
+                      publicSettings={publicSettings}
+                      setPrivateSettings={setPrivateSettings}
+                      setPublicSettings={setPublicSettings}
+                      setActivePanel={setActivePanel}
+                      smitheryApiKey={smitheryApiKey}
+                      setSmitheryApiKey={setSmitheryApiKey}
+                      smitheryServers={smitheryServers}
+                      setSmitheryServers={setSmitheryServers}
+                    />
+                  </CardContent>
+                </Card>
+              </Suspense>
+            )}
+
+            <Card
+              className={cn(
+                PANEL_BASE_CLASS,
+                'w-full max-w-2xl transition-all duration-300',
+                shouldShowResponsePanel ? 'xl:max-w-2xl' : 'xl:max-w-4xl'
               )}
-
-              {/* Main Search Card */}
-              <Card
-                className="bg-background/95 shadow-2xl flex flex-col transition-all duration-200 rounded-xl overflow-hidden"
-                style={{ width: 600 }}
-                data-highlight="search-container"
-              >
+              data-highlight="search-container"
+            >
                 <CardContent
                   className={cn(
-                    'p-0 flex flex-col',
+                    'flex flex-col p-0',
                     showResults && searchResults.length > 0 ? 'h-[600px]' : 'h-auto'
                   )}
                 >
@@ -1424,27 +1454,29 @@ Keep your response focused and concise.`,
                       showResults && searchResults.length > 0 ? 'h-full' : 'h-auto'
                     )}
                   >
-                    {/* Search Bar Section */}
                     {searchSteps.length > 0 && (
-                      <div className="px-4 pt-4">
+                      <div className="px-6 pt-6">
                         <SearchBadges steps={searchSteps} />
                       </div>
                     )}
-                    <SearchBar
-                      ref={searchBarRef}
-                      query={query}
-                      setQuery={setQuery}
-                      isLoading={isLoading}
-                      useAgent={useAgent}
-                      handleAgentToggle={(checked) => {
-                        setUseAgent(checked);
-                        localStorage.setItem('use-agent', JSON.stringify(checked));
-                      }}
-                      handleInputChange={handleInputChange}
-                      data-highlight="search-input"
-                    />
+                    <div className="px-6 pb-6">
+                      <SearchBar
+                        ref={searchBarRef}
+                        query={query}
+                        setQuery={setQuery}
+                        isLoading={isLoading}
+                        useAgent={useAgent}
+                        handleAgentToggle={setUseAgent}
+                        handleInputChange={handleInputChange}
+                        onOpenSettings={toggleSettingsPanel}
+                        isSettingsActive={isSettingsActive}
+                        connectorSummary={connectorSummary}
+                        connectorCount={activeSmitheryServers.length}
+                        connectorSyncing={isSmitheryLoading}
+                        data-highlight="search-input"
+                      />
+                    </div>
 
-                    {/* Results Section */}
                     {showResults && (
                       <SearchResults
                         searchResults={searchResults}
@@ -1454,19 +1486,29 @@ Keep your response focused and concise.`,
                         data-highlight="search-results"
                       />
                     )}
+                    {(smitheryServers.length > 0 || query.trim().length > 0) && (
+                      <div className="px-6 pb-6">
+                        <SmitheryContextResults
+                          items={smitheryResults}
+                          servers={smitheryServers}
+                          isLoading={isSmitheryLoading}
+                          error={smitheryError}
+                          onOpenSettings={toggleSettingsPanel}
+                          onRefreshServer={refreshSmitheryServer}
+                        />
+                      </div>
+                    )}
                   </div>
                 </CardContent>
               </Card>
 
-              {/* AI Response Panel */}
-              {conversations.length > 0 && activePanel === 'response' && (
+            {shouldShowResponsePanel && (
                 <Suspense fallback={<div>Loading Response Panel...</div>}>
                   <Card
-                    className="bg-background/95 shadow-2xl flex flex-col transition-all duration-200 rounded-xl overflow-hidden"
-                    style={{ width: 600 }}
+                    className={cn(PANEL_BASE_CLASS, 'w-full max-w-2xl')}
                     data-highlight="response-panel"
                   >
-                    <CardContent className="p-4 flex flex-col h-[600px]">
+                    <CardContent className="flex h-[600px] flex-col p-6">
                       <ResponsePanel
                         conversations={conversations}
                         addAIResponseToContext={() => {}}
@@ -1483,60 +1525,57 @@ Keep your response focused and concise.`,
                   </Card>
                 </Suspense>
               )}
-            </div>
-
-            <KeyboardShortcuts
-              showDocument={activePanel === 'document'}
-              activePanel={activePanel}
-              data-highlight="keyboard-shortcuts"
-            />
           </div>
 
-          {/* Sticky Notes Layer */}
-          <AnimatePresence>
-            {stickyNotes.map((note) => (
-              <StickyNoteComponent
-                key={note.id}
-                note={note}
-                onClose={(id) => {
-                  setStickyNotes((prev) => prev.filter((n) => n.id !== id));
-                }}
-                onDrag={(id, position) => {
-                  // Direct update without requestAnimationFrame
-                  setStickyNotes((prev) =>
-                    prev.map((n) =>
-                      n.id === id
-                        ? {
-                            ...n,
-                            position: {
-                              x: Math.max(0, Math.min(window.innerWidth - 384, position.x)),
-                              y: Math.max(0, Math.min(window.innerHeight - 400, position.y)),
-                            },
-                          }
-                        : n
-                    )
-                  );
-                }}
-                onEdit={(id, newText) => {
-                  setStickyNotes((prev) =>
-                    prev.map((n) =>
-                      n.id === id
-                        ? {
-                            ...n,
-                            text: newText,
-                            metadata: {
-                              ...n.metadata,
-                              modified_at: Date.now() / 1000,
-                            },
-                          }
-                        : n
-                    )
-                  );
-                }}
-              />
-            ))}
-          </AnimatePresence>
+          <KeyboardShortcuts
+            showDocument={activePanel === 'document'}
+            activePanel={activePanel}
+            data-highlight="keyboard-shortcuts"
+          />
         </div>
+
+        <AnimatePresence>
+          {stickyNotes.map((note) => (
+            <StickyNoteComponent
+              key={note.id}
+              note={note}
+              onClose={(id) => {
+                setStickyNotes((prev) => prev.filter((n) => n.id !== id));
+              }}
+              onDrag={(id, position) => {
+                setStickyNotes((prev) =>
+                  prev.map((n) =>
+                    n.id === id
+                      ? {
+                          ...n,
+                          position: {
+                            x: Math.max(0, Math.min(window.innerWidth - 384, position.x)),
+                            y: Math.max(0, Math.min(window.innerHeight - 400, position.y)),
+                          },
+                        }
+                      : n
+                  )
+                );
+              }}
+              onEdit={(id, newText) => {
+                setStickyNotes((prev) =>
+                  prev.map((n) =>
+                    n.id === id
+                      ? {
+                          ...n,
+                          text: newText,
+                          metadata: {
+                            ...n.metadata,
+                            modified_at: Date.now() / 1000,
+                          },
+                        }
+                      : n
+                  )
+                );
+              }}
+            />
+          ))}
+        </AnimatePresence>
       </DropArea>
     </DndProvider>
   );

--- a/src/renderer/src/assets/index.css
+++ b/src/renderer/src/assets/index.css
@@ -15,75 +15,86 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.3rem;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --h1-size: 2.25rem;    /* 36px */
-    --h2-size: 1.875rem;   /* 30px */
-    --h3-size: 1.5rem;     /* 24px */
-    --h4-size: 1.25rem;    /* 20px */
-    --h5-size: 1.125rem;   /* 18px */
-    --h6-size: 1rem;       /* 16px */
+    color-scheme: dark;
+    --background: 222 47% 7%;
+    --foreground: 210 40% 96%;
+    --card: 222 47% 10%;
+    --card-foreground: 210 40% 96%;
+    --popover: 222 47% 9%;
+    --popover-foreground: 210 40% 96%;
+    --primary: 199 89% 58%;
+    --primary-foreground: 210 40% 96%;
+    --secondary: 221 36% 18%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 222 32% 20%;
+    --muted-foreground: 215 20% 72%;
+    --accent: 199 90% 65%;
+    --accent-foreground: 222 47% 12%;
+    --destructive: 0 72% 45%;
+    --destructive-foreground: 210 40% 96%;
+    --border: 218 36% 26%;
+    --input: 218 36% 26%;
+    --ring: 199 90% 65%;
+    --radius: 1.5rem;
+    --chart-1: 198 88% 63%;
+    --chart-2: 264 85% 68%;
+    --chart-3: 158 67% 58%;
+    --chart-4: 43 96% 62%;
+    --chart-5: 340 82% 66%;
+    --h1-size: 2.5rem;
+    --h2-size: 2.125rem;
+    --h3-size: 1.75rem;
+    --h4-size: 1.5rem;
+    --h5-size: 1.25rem;
+    --h6-size: 1.125rem;
     --heading-font-weight: 600;
     --heading-line-height: 1.25;
     --heading-margin: 1.5rem 0 1rem;
   }
 
-  .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
+  body {
+    @apply min-h-screen bg-slate-950 text-slate-100 antialiased;
+    background-attachment: fixed;
+    background-image:
+      radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.22), transparent 55%),
+      radial-gradient(circle at 80% 0%, rgba(236, 72, 153, 0.18), transparent 60%),
+      linear-gradient(160deg, rgba(2, 6, 23, 0.92), rgba(15, 23, 42, 0.94));
+    overflow-x: hidden;
+    position: relative;
   }
 
-  /* Markdown heading styles */
-  h1, h2, h3, h4, h5, h6 {
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at 50% 0%, rgba(56, 189, 248, 0.12), transparent 60%);
+    opacity: 0.8;
+    z-index: -1;
+  }
+
+  body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI4IiBoZWlnaHQ9IjEyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZmlsdGVyIGlkPSJhIiB4PSIwIiB5PSIwIiB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWx0ZXJVbml0cz0ib2JqZWN0Qm91bmRpbmdCb3giPjxmZVR1cmJ1bGVuY2UgdHlwZT0icm91ZyIgbnVtT2N0YXZlcz0iNCIgc3RpdGNoVGlsZXM9InN0aXRjaCIgc2lkZUluPSJzb3VyY2VBbHBoYSIgYmFzZUZyZXF1ZW5jeT0iMSIvPjxmZUZsb29kIGZsb29kLWNvbG9yPSJyZ2JhKDAsIDAsIDAsIDAuMTUpIi8+PC9maWx0ZXI+PHJlY3Qgd2lkdGg9IjEyOCIgaGVpZ2h0PSIxMjgiIGZpbHRlcj0idXJsKCNhKSIgZmlsbD0iI2ZmZiIgb3BhY2l0eT0iMC4yNSIvPjwvc3ZnPg==');
+    opacity: 0.35;
+    mix-blend-mode: soft-light;
+    z-index: -1;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-weight: var(--heading-font-weight);
     line-height: var(--heading-line-height);
     margin: var(--heading-margin);
     color: hsl(var(--foreground));
+    letter-spacing: -0.01em;
   }
 
   h1 { font-size: var(--h1-size); }
@@ -92,4 +103,66 @@
   h4 { font-size: var(--h4-size); }
   h5 { font-size: var(--h5-size); }
   h6 { font-size: var(--h6-size); }
+}
+
+@layer utilities {
+  @keyframes float {
+    0% {
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+    50% {
+      transform: translate3d(25px, -35px, 0) scale(1.04);
+    }
+    100% {
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+  }
+
+  .animate-float-slow {
+    animation: float 24s ease-in-out infinite;
+  }
+
+  .animate-float-medium {
+    animation: float 18s ease-in-out infinite;
+  }
+
+  .glass-panel {
+    position: relative;
+    border-radius: 1.75rem;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.42));
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    box-shadow: 0 32px 120px -60px rgba(15, 23, 42, 0.85);
+    backdrop-filter: blur(26px);
+  }
+
+  .glass-panel::before {
+    content: '';
+    position: absolute;
+    inset: 1px;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.14), rgba(14, 165, 233, 0.05));
+    opacity: 0;
+    transition: opacity 0.6s ease;
+    z-index: 0;
+  }
+
+  .glass-panel:hover::before {
+    opacity: 1;
+  }
+
+  .glass-panel > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  .glass-grid {
+    position: absolute;
+    inset: -10%;
+    background-image:
+      linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+      linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+    background-size: 120px 120px;
+    mask-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.4), transparent 70%);
+    pointer-events: none;
+  }
 }

--- a/src/renderer/src/components/ResponsePanel.tsx
+++ b/src/renderer/src/components/ResponsePanel.tsx
@@ -7,6 +7,8 @@ import ReactMarkdown from 'react-markdown'
 import { useDrag } from 'react-dnd'
 import { Input } from '@/components/ui/input'
 import { trpcClient } from '../util/trpc-client'
+import type { SearchResult } from '../types/search'
+import type { AIResponse } from '../types'
 
 interface ResponsePanelProps {
   conversations: AIResponse[]
@@ -27,22 +29,6 @@ interface ResponsePanelProps {
   setSearchResults: React.Dispatch<React.SetStateAction<SearchResult[]>>
   setShowResults: React.Dispatch<React.SetStateAction<boolean>>
   filterOutStickyNotes: (results: SearchResult[]) => SearchResult[]
-}
-
-interface AIResponse {
-  question: string
-  answer: string
-  timestamp: number
-  sources?: Array<{
-    path: string
-    preview?: string
-    citations?: string[]
-  }>
-  commit?: {
-    hash: string
-    message: string
-    diff: string
-  }
 }
 
 const handlePathClick = async (path: string, e: React.MouseEvent): Promise<void> => {

--- a/src/renderer/src/components/SearchBadges.tsx
+++ b/src/renderer/src/components/SearchBadges.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { Badge } from '@/components/ui/badge'
-import type { SearchResult } from '../App'
+import type { SearchResult } from '../types/search'
 import { cn } from '@/lib/utils'
 import { Loader2, CheckCircle2, XCircle } from 'lucide-react'
 

--- a/src/renderer/src/components/SearchBar.tsx
+++ b/src/renderer/src/components/SearchBar.tsx
@@ -1,7 +1,16 @@
 import React, { useRef, useImperativeHandle, forwardRef } from 'react';
 import { Input } from '@/components/ui/input';
-import { Search, Loader2, Lock, LockOpen, FastForwardIcon, BotIcon } from 'lucide-react';
+import {
+  Search,
+  Loader2,
+  FastForwardIcon,
+  BotIcon,
+  Settings2,
+  Sparkles,
+  RadioTower,
+} from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
 
 interface SearchBarProps {
   query: string;
@@ -10,62 +19,126 @@ interface SearchBarProps {
   useAgent: boolean;
   handleAgentToggle: (checked: boolean) => void;
   handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onOpenSettings: () => void;
+  isSettingsActive: boolean;
+  connectorSummary: string;
+  connectorCount: number;
+  connectorSyncing: boolean;
 }
 
 export interface SearchBarRef {
   focus: () => void;
 }
 
-const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(({
-  query,
-  isLoading,
-  useAgent,
-  handleAgentToggle,
-  handleInputChange,
-}, ref) => {
-  const inputRef = useRef<HTMLInputElement>(null);
+const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(
+  (
+    {
+      query,
+      isLoading,
+      useAgent,
+      handleAgentToggle,
+      handleInputChange,
+      onOpenSettings,
+      isSettingsActive,
+      connectorSummary,
+      connectorCount,
+      connectorSyncing,
+    },
+    ref
+  ) => {
+    const inputRef = useRef<HTMLInputElement>(null);
 
-  useImperativeHandle(ref, () => ({
-    focus: () => {
-      inputRef.current?.focus();
-    }
-  }));
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        inputRef.current?.focus();
+      },
+    }));
 
-  return (
-    <div className="relative rounded-t-xl overflow-hidden">
-      <Search 
-        className="absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground h-5 w-5" 
-      />
-      <Input
-        ref={inputRef}
-        type="text"
-        value={query}
-        onChange={handleInputChange}
-        placeholder={query ? 'Ask a follow-up question...' : 'Search...'}
-        className="w-full pl-12 pr-24 py-4 text-xl border-none focus-visible:ring-0 bg-background/95 backdrop-blur-sm text-foreground"
-      />
-      <div className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-2">
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">
-            {useAgent ? (
-              <BotIcon className="h-4 w-4" />
-            ) : (
-              <FastForwardIcon className="h-4 w-4" />
-            )}
-          </span>
-          <Switch
-            checked={useAgent}
-            onCheckedChange={handleAgentToggle}
-            className="data-[state=checked]:bg-primary"
-            title={useAgent ? "Agent-assisted search enabled" : "Direct search"}
-          />
+    return (
+      <div className="space-y-2">
+        <div className="glass-panel relative overflow-hidden rounded-[30px] border border-white/10 p-[1px] shadow-[0_40px_120px_-70px_rgba(56,189,248,0.6)]">
+          <div className="pointer-events-none absolute inset-0 rounded-[30px] bg-gradient-to-r from-sky-400/10 via-transparent to-fuchsia-400/10 opacity-70" />
+          <div className="relative flex items-center gap-4 rounded-[28px] bg-slate-950/60 px-6 py-4">
+            <div className="relative flex h-11 w-11 items-center justify-center rounded-2xl bg-white/5 text-slate-200 shadow-inner shadow-white/5">
+              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-sky-500/30 to-transparent" />
+              <Search className="relative h-5 w-5" />
+            </div>
+            <div className="flex-1">
+              <Input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={handleInputChange}
+                placeholder={query ? 'Ask a follow-up question…' : 'Search anything…'}
+                className="h-14 w-full rounded-full border-none bg-transparent px-4 text-lg font-medium text-slate-100 placeholder:text-slate-400 focus-visible:ring-0 focus-visible:ring-offset-0"
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="hidden sm:flex flex-col items-end gap-2">
+                <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-slate-100/90 backdrop-blur-lg">
+                  <Badge
+                    variant="secondary"
+                    className="flex items-center gap-1 rounded-full border-white/10 bg-white/10 px-2 py-0 text-[11px] uppercase tracking-[0.2em] text-slate-200/90"
+                  >
+                    <Sparkles className="h-3 w-3" />
+                    {useAgent ? 'Agentic' : 'Direct'}
+                  </Badge>
+                  <Switch
+                    checked={useAgent}
+                    onCheckedChange={handleAgentToggle}
+                    className="data-[state=checked]:bg-sky-400/90 data-[state=checked]:shadow-[0_0_18px_rgba(125,211,252,0.6)]"
+                    title={useAgent ? 'Agent-assisted search enabled' : 'Direct search'}
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={onOpenSettings}
+                  className="group flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] uppercase tracking-[0.26em] text-slate-200/80 transition hover:border-white/20 hover:bg-white/10"
+                >
+                  <RadioTower className="h-3.5 w-3.5 text-sky-200" />
+                  {connectorSummary}
+                  {connectorSyncing && <Loader2 className="h-3.5 w-3.5 animate-spin text-sky-200" />}
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={onOpenSettings}
+                className="group relative flex h-11 w-11 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-slate-200 transition hover:border-white/20 hover:bg-white/10"
+                aria-pressed={isSettingsActive}
+                aria-label="Toggle settings"
+              >
+                <div className="absolute inset-0 rounded-2xl opacity-0 transition group-hover:opacity-100 group-aria-[pressed=true]:opacity-100" style={{ background: 'linear-gradient(135deg, rgba(125,211,252,0.35), rgba(244,114,182,0.25))' }} />
+                <Settings2 className="relative h-5 w-5" />
+              </button>
+              <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
+                {isLoading ? (
+                  <Loader2 className="h-5 w-5 animate-spin text-sky-200" />
+                ) : (
+                  <BotIcon
+                    className={`h-5 w-5 ${useAgent ? 'text-sky-200' : 'text-slate-300/70'}`}
+                    aria-hidden="true"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
         </div>
-        {isLoading && <Loader2 className="h-5 w-5 animate-spin ml-2" />}
+        <div className="flex flex-wrap justify-between gap-3 px-4 text-xs text-slate-300/70">
+          <span>
+            Press ⏎ to run an in-depth search • ⌘/Ctrl + C to copy context
+            {connectorCount > 0 &&
+              ` • ${connectorCount} MCP ${connectorCount === 1 ? 'connector' : 'connectors'} linked`}
+          </span>
+          <span className="flex items-center gap-1">
+            <FastForwardIcon className="h-3 w-3 text-slate-300/80" />
+            <span>⌘/Ctrl + K opens your knowledgebase</span>
+          </span>
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 SearchBar.displayName = 'SearchBar';
 
-export default SearchBar; 
+export default SearchBar;

--- a/src/renderer/src/components/SearchResults.tsx
+++ b/src/renderer/src/components/SearchResults.tsx
@@ -7,23 +7,8 @@ import { cn } from '@/lib/utils';
 import { trpcClient } from '../util/trpc-client';
 import { RankedChunk } from '@/lib/context-utils';
 import { useDrag } from 'react-dnd';
-
-interface SearchResult {
-  text: string;
-  dist: number;
-  metadata: {
-    path: string;
-    title?: string;
-    created_at: number;
-    modified_at: number;
-    filetype: string;
-    languages: string[];
-    links: string[];
-    owner: string | null;
-    seen_at: number;
-    sourceType?: 'document' | 'web';
-  };
-}
+import { Badge } from '@/components/ui/badge';
+import type { SearchResult } from '../types/search';
 
 interface SearchResultsProps {
   searchResults: SearchResult[];
@@ -101,71 +86,88 @@ const SearchResultItem: React.FC<{
 
   const truncatedContent = truncateText(chunk.combinedText, 500);
 
+  const selectionClasses =
+    index === selectedIndex
+      ? 'ring-1 ring-sky-300/70 shadow-[0_40px_120px_-60px_rgba(125,211,252,0.55)]'
+      : 'shadow-[0_24px_80px_-70px_rgba(15,23,42,0.85)]';
+
+  const variantLabel = isWebSource ? 'Web source' : 'Local file';
+  const formattedScore = Math.max(0, chunk.score || 0).toFixed(2);
+
   return (
     <div
       ref={drag}
-      style={{ opacity: isDragging ? 0.5 : 1 }}
+      style={{ opacity: isDragging ? 0.35 : 1 }}
       className={cn(
-        'card-item m-2',
+        'card-item m-2 transition-transform duration-300 ease-out hover:-translate-y-1.5',
         index === selectedIndex ? 'z-10' : 'z-0'
       )}
     >
       <Card
         className={cn(
-          'hover:bg-accent/50 transition-all duration-200 rounded-xl overflow-hidden backdrop-blur-sm',
-          index === selectedIndex
-            ? 'bg-accent/95 border-primary'
-            : 'bg-background/95'
+          'glass-panel group relative overflow-hidden rounded-[26px] border border-white/10 bg-slate-950/65 backdrop-blur-2xl',
+          selectionClasses
         )}
         onClick={() => handleResultClick(result)}
       >
-        <CardContent className="p-3 flex items-start space-x-3">
-          <div className="flex gap-2">
-            <div className="bg-muted rounded-full p-2 mt-1">
-              {isWebSource ? (
-                <Globe className="h-4 w-4 text-muted-foreground" />
-              ) : (
-                <FileText className="h-4 w-4 text-muted-foreground" />
-              )}
-            </div>
+        <div className="pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-100" style={{ background: 'linear-gradient(135deg, rgba(56,189,248,0.12), rgba(236,72,153,0.08))' }} />
+        <CardContent className="relative flex items-start gap-4 p-5">
+          <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-sky-200">
+            {isWebSource ? (
+              <Globe className="h-5 w-5" />
+            ) : (
+              <FileText className="h-5 w-5" />
+            )}
           </div>
-          <div className="flex-1">
-            <h3 className="text-sm font-semibold flex items-center gap-2">
-              <span
-                onClick={(e) => handlePathClick(result.metadata.path, e)}
-                className="hover:text-primary cursor-pointer transition-colors flex items-center gap-1"
-                title={result.metadata.path}
+          <div className="flex-1 space-y-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap items-center gap-2 text-sm font-semibold text-slate-100">
+                <button
+                  type="button"
+                  onClick={(e) => handlePathClick(result.metadata.path, e)}
+                  className="group/button inline-flex items-center gap-1 rounded-full bg-white/5 px-3 py-1 text-left text-sm font-semibold text-white transition hover:bg-white/10"
+                  title={result.metadata.path}
+                >
+                  {displayName}
+                  {isWebSource ? (
+                    <ExternalLink className="h-3 w-3 text-slate-200" />
+                  ) : (
+                    <FileText className="h-3 w-3 text-slate-200" />
+                  )}
+                </button>
+                <Badge className="rounded-full border-white/10 bg-white/10 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-200/90">
+                  {variantLabel}
+                </Badge>
+              </div>
+              <Badge
+                variant="secondary"
+                className="rounded-full border-white/10 bg-white/10 px-3 py-1 text-[11px] font-semibold text-slate-100"
               >
-                {displayName}
-                {isWebSource ? (
-                  <ExternalLink className="h-3 w-3" />
-                ) : (
-                  <FileText className="h-3 w-3" />
-                )}
-              </span>
-              <span className="text-xs font-normal text-muted-foreground">
-                {isWebSource ? 'Web' : 'Document'}
-              </span>
-            </h3>
+                Relevance {formattedScore}
+              </Badge>
+            </div>
+
             {isWebSource && (
               <div
-                className="text-xs text-muted-foreground mt-1 hover:text-primary cursor-pointer transition-colors"
+                className="inline-flex max-w-full items-center gap-2 truncate text-xs text-slate-300/80"
                 onClick={(e) => handlePathClick(result.metadata.path, e)}
                 title={result.metadata.path}
               >
-                {truncateText(result.metadata.path, 100)}
+                <ExternalLink className="h-3 w-3 flex-shrink-0" />
+                <span className="truncate">{truncateText(result.metadata.path, 100)}</span>
               </div>
             )}
-            <div className="text-xs text-muted-foreground mt-1 prose prose-sm max-w-none">
+
+            <div className="prose prose-invert prose-sm max-w-none text-slate-200/90">
               <ReactMarkdown>{truncatedContent}</ReactMarkdown>
             </div>
-            <div className="flex items-center mt-2 space-x-2">
-              <span className="text-xs text-muted-foreground">
-                Modified:{' '}
-                {new Date(
-                  result.metadata.modified_at * 1000
-                ).toLocaleDateString()}
+
+            <div className="flex flex-wrap items-center gap-3 text-xs text-slate-300/70">
+              <span>
+                Modified{' '}
+                {new Date(result.metadata.modified_at * 1000).toLocaleDateString()}
               </span>
+              <span>Drag to pin as a floating note</span>
             </div>
           </div>
         </CardContent>
@@ -216,12 +218,12 @@ const SearchResults: React.FC<SearchResultsProps> = React.memo(
     return (
       <div
         className={cn(
-          'flex-1 overflow-hidden rounded-b-xl',
-          searchResults.length === 0 ? 'h-0' : ''
+          'flex-1 overflow-hidden rounded-b-[28px] border border-white/10 bg-white/5 backdrop-blur-xl',
+          searchResults.length === 0 ? 'h-0 border-0 bg-transparent' : ''
         )}
       >
         <ScrollArea
-          className={cn('h-full', searchResults.length === 0 ? 'p-0' : '')}
+          className={cn('h-full px-2 py-3', searchResults.length === 0 ? 'p-0' : '')}
         >
           {groupedChunks.map((chunk, index) => {
             const result = searchResults.find(
@@ -242,11 +244,13 @@ const SearchResults: React.FC<SearchResultsProps> = React.memo(
           })}
         </ScrollArea>
         {searchResults.length > 0 && (
-          <div className="flex items-center justify-between mt-2 px-4 pb-2 text-xs text-muted-foreground bg-background/95 backdrop-blur-sm rounded-b-xl">
+          <div className="glass-panel mx-3 mb-3 flex items-center justify-between rounded-[24px] border border-white/10 bg-slate-950/60 px-4 py-3 text-[11px] text-slate-200/80">
             <span>
-              {selectedIndex === -1 ? 'Press → to pin to context' : 'Press ↑ to select'}
+              {selectedIndex === -1
+                ? 'Press → to pin highlighted context'
+                : 'Use ↑ / ↓ to explore results'}
             </span>
-            <span>Drag items to create sticky notes</span>
+            <span className="hidden sm:inline">Drag cards to create floating notes</span>
           </div>
         )}
       </div>

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -1,12 +1,16 @@
-// @components/SettingsPanel.tsx
-import React, { useEffect, useRef, useState } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import { Lock, LockOpen } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { LLMSettings } from '@/types';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Loader2, Lock, LockOpen, PlugZap, RefreshCcw, ShieldCheck, Trash2 } from 'lucide-react';
+import type { LLMSettings, SmitheryDirectoryEntry, SmitheryMCPServer } from '@/types';
+import {
+  buildSmitheryManifestUrl,
+  createSmitheryServerFromInput,
+  fetchSmitheryDirectory,
+} from '@/lib/smithery';
 
 interface SettingsPanelProps {
   isPrivate: boolean;
@@ -16,6 +20,10 @@ interface SettingsPanelProps {
   setPrivateSettings: (settings: LLMSettings) => void;
   setPublicSettings: (settings: LLMSettings) => void;
   setActivePanel: (panel: 'none' | 'chat' | 'document' | 'settings') => void;
+  smitheryApiKey: string;
+  setSmitheryApiKey: (apiKey: string) => void;
+  smitheryServers: SmitheryMCPServer[];
+  setSmitheryServers: React.Dispatch<React.SetStateAction<SmitheryMCPServer[]>>;
 }
 
 const SettingsPanel: React.FC<SettingsPanelProps> = ({
@@ -26,9 +34,24 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
   setPrivateSettings,
   setPublicSettings,
   setActivePanel,
+  smitheryApiKey,
+  setSmitheryApiKey,
+  smitheryServers,
+  setSmitheryServers,
 }) => {
-  const [localSettings, setLocalSettings] = useState<LLMSettings>(isPrivate ? privateSettings : publicSettings);
+  const [localSettings, setLocalSettings] = useState<LLMSettings>(
+    isPrivate ? privateSettings : publicSettings
+  );
   const baseUrlRef = useRef<HTMLInputElement>(null);
+
+  const [localSmitheryKey, setLocalSmitheryKey] = useState<string>(smitheryApiKey);
+  const [newConnector, setNewConnector] = useState<string>('');
+  const [smitheryError, setSmitheryError] = useState<string | null>(null);
+  const [directory, setDirectory] = useState<SmitheryDirectoryEntry[]>([]);
+  const [isSavingSmithery, setIsSavingSmithery] = useState(false);
+  const [isDirectoryLoading, setIsDirectoryLoading] = useState(false);
+  const [directoryError, setDirectoryError] = useState<string | null>(null);
+  const [directoryVersion, setDirectoryVersion] = useState(0);
 
   useEffect(() => {
     baseUrlRef.current?.focus();
@@ -38,94 +61,439 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
     setLocalSettings(isPrivate ? privateSettings : publicSettings);
   }, [isPrivate, privateSettings, publicSettings]);
 
+  useEffect(() => {
+    setLocalSmitheryKey(smitheryApiKey);
+  }, [smitheryApiKey]);
+
+  const effectiveSmitheryKey = useMemo(() => {
+    const candidate = (localSmitheryKey || smitheryApiKey || '').trim();
+    return candidate.length > 0 ? candidate : undefined;
+  }, [localSmitheryKey, smitheryApiKey]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const controller = new AbortController();
+
+    const loadDirectory = async () => {
+      setIsDirectoryLoading(true);
+      setDirectoryError(null);
+      try {
+        const entries = await fetchSmitheryDirectory({
+          apiKey: smitheryApiKey || undefined,
+          signal: controller.signal,
+        });
+        if (isMounted) {
+          setDirectory(entries);
+        }
+      } catch (error) {
+        if (!isMounted || (error instanceof DOMException && error.name === 'AbortError')) {
+          return;
+        }
+        console.warn('Failed to fetch Smithery directory', error);
+        setDirectoryError('Unable to reach Smithery directory right now.');
+      } finally {
+        if (isMounted) {
+          setIsDirectoryLoading(false);
+        }
+      }
+    };
+
+    loadDirectory();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [smitheryApiKey, directoryVersion]);
+
   const handleSaveSettings = () => {
     if (isPrivate) {
       setPrivateSettings(localSettings);
-      localStorage.setItem('llm-settings-private', JSON.stringify(localSettings));
     } else {
       setPublicSettings(localSettings);
-      localStorage.setItem('llm-settings-public', JSON.stringify(localSettings));
     }
     setActivePanel('none');
   };
 
+  const handleSaveSmitheryKey = () => {
+    setSmitheryApiKey((localSmitheryKey || '').trim());
+    setSmitheryError(null);
+  };
+
+  const upsertServer = useCallback(
+    (server: SmitheryMCPServer) => {
+      setSmitheryServers((prev) => {
+        const existing = prev.find((item) => item.id === server.id || item.slug === server.slug);
+        const merged = existing
+          ? { ...server, enabled: existing.enabled }
+          : server;
+        const filtered = prev.filter((item) => item.id !== merged.id);
+        return [...filtered, merged].sort((a, b) => a.name.localeCompare(b.name));
+      });
+    },
+    [setSmitheryServers]
+  );
+
+  const handleAddConnector = async (input?: string) => {
+    const target = (input ?? newConnector).trim();
+    if (!target) {
+      setSmitheryError('Provide a Smithery slug or manifest URL.');
+      return;
+    }
+
+    setIsSavingSmithery(true);
+    setSmitheryError(null);
+    try {
+      const server = await createSmitheryServerFromInput(target, {
+        apiKey: effectiveSmitheryKey,
+      });
+      upsertServer(server);
+      setNewConnector('');
+    } catch (error) {
+      console.error('Failed to add Smithery connector', error);
+      setSmitheryError(
+        error instanceof Error ? error.message : 'Unable to add Smithery connector.'
+      );
+    } finally {
+      setIsSavingSmithery(false);
+    }
+  };
+
+  const handleAddDirectoryEntry = async (entry: SmitheryDirectoryEntry) => {
+    const manifest = entry.manifestUrl ?? buildSmitheryManifestUrl(entry.slug);
+    await handleAddConnector(manifest);
+  };
+
+  const handleRefreshConnector = async (server: SmitheryMCPServer) => {
+    setIsSavingSmithery(true);
+    setSmitheryError(null);
+    try {
+      const refreshed = await createSmitheryServerFromInput(server.manifestUrl ?? server.slug, {
+        apiKey: effectiveSmitheryKey,
+        existing: server,
+      });
+      upsertServer({ ...refreshed, enabled: server.enabled });
+    } catch (error) {
+      console.error('Failed to refresh Smithery connector', error);
+      setSmitheryError(
+        error instanceof Error ? error.message : 'Unable to refresh connector metadata.'
+      );
+    } finally {
+      setIsSavingSmithery(false);
+    }
+  };
+
+  const handleToggleConnector = (serverId: string, enabled: boolean) => {
+    setSmitheryServers((prev) =>
+      prev.map((server) => (server.id === serverId ? { ...server, enabled } : server))
+    );
+  };
+
+  const handleRemoveConnector = (serverId: string) => {
+    setSmitheryServers((prev) => prev.filter((server) => server.id !== serverId));
+  };
+
+  const activeConnectors = useMemo(
+    () => smitheryServers.filter((server) => server.enabled !== false),
+    [smitheryServers]
+  );
+
   return (
-    <div className="flex flex-col h-full" onClick={(e) => e.stopPropagation()}>
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-semibold">Settings</h2>
-      </div>
-      <div className="grid gap-4 py-4">
-        <div className="flex items-center justify-between">
-          <div className="grid gap-1">
-            <label htmlFor="privacy" className="text-sm font-medium">
-              Private Mode
-            </label>
-            <span className="text-xs text-muted-foreground">
-              {isPrivate ? 'Using local LLM' : 'Using cloud LLM'}
-            </span>
+    <div className="flex h-full flex-col gap-6" onClick={(event) => event.stopPropagation()}>
+      <header className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Workspace preferences</h2>
+          <p className="text-xs text-slate-300/80">
+            Configure language models and connect Smithery MCP servers to enrich search context.
+          </p>
+        </div>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between rounded-3xl border border-white/10 bg-white/5 px-4 py-3">
+          <div>
+            <p className="text-sm font-medium text-white">Privacy mode</p>
+            <p className="text-xs text-slate-300/75">
+              {isPrivate ? 'Run prompts against your local Ollama stack.' : 'Use cloud-hosted models via OpenRouter.'}
+            </p>
           </div>
-          <Switch
-            id="privacy"
-            checked={isPrivate}
-            onCheckedChange={(checked) => {
-              setIsPrivate(checked);
-              localStorage.setItem('llm-privacy', JSON.stringify(checked));
-            }}
-            className="data-[state=checked]:bg-primary"
-          />
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/5">
+              {isPrivate ? <Lock className="h-4 w-4 text-emerald-200" /> : <LockOpen className="h-4 w-4 text-sky-200" />}
+            </div>
+            <Switch
+              id="privacy"
+              checked={isPrivate}
+              onCheckedChange={(checked) => {
+                setIsPrivate(checked);
+              }}
+              className="data-[state=checked]:bg-sky-400/90"
+            />
+          </div>
         </div>
-        <div className="grid gap-2">
-          <label htmlFor="baseUrl" className="text-sm font-medium">
-            Base URL
-          </label>
-          <Input
-            ref={baseUrlRef}
-            id="baseUrl"
-            value={localSettings.baseUrl}
-            onChange={(e) =>
-              setLocalSettings((prev) => ({
-                ...prev,
-                baseUrl: e.target.value,
-              }))
-            }
-            placeholder={isPrivate ? 'http://localhost:11434/v1' : 'https://api.openai.com/v1'}
-          />
+
+        <div className="grid gap-3 rounded-3xl border border-white/10 bg-white/5 p-5">
+          <div className="grid gap-2">
+            <label htmlFor="baseUrl" className="text-xs uppercase tracking-[0.3em] text-slate-300/70">
+              Base URL
+            </label>
+            <Input
+              ref={baseUrlRef}
+              id="baseUrl"
+              value={localSettings.baseUrl}
+              onChange={(event) =>
+                setLocalSettings((prev) => ({
+                  ...prev,
+                  baseUrl: event.target.value,
+                }))
+              }
+              placeholder={isPrivate ? 'http://localhost:11434/v1' : 'https://openrouter.ai/api/v1'}
+            />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="apiKey" className="text-xs uppercase tracking-[0.3em] text-slate-300/70">
+              API key {isPrivate && '(optional)'}
+            </label>
+            <Input
+              id="apiKey"
+              type="password"
+              value={localSettings.apiKey}
+              onChange={(event) =>
+                setLocalSettings((prev) => ({
+                  ...prev,
+                  apiKey: event.target.value,
+                }))
+              }
+              placeholder={isPrivate ? 'ollama-key (optional)' : 'sk-...'}
+            />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="model" className="text-xs uppercase tracking-[0.3em] text-slate-300/70">
+              Default model
+            </label>
+            <Input
+              id="model"
+              value={localSettings.model}
+              onChange={(event) =>
+                setLocalSettings((prev) => ({
+                  ...prev,
+                  model: event.target.value,
+                }))
+              }
+              placeholder={isPrivate ? 'llama3.2:3b' : 'openai/gpt-4o-mini'}
+            />
+          </div>
         </div>
-        <div className="grid gap-2">
-          <label htmlFor="apiKey" className="text-sm font-medium">
-            API Key {isPrivate && '(Optional)'}
-          </label>
-          <Input
-            id="apiKey"
-            type="password"
-            value={localSettings.apiKey}
-            onChange={(e) =>
-              setLocalSettings((prev) => ({
-                ...prev,
-                apiKey: e.target.value,
-              }))
-            }
-            placeholder={isPrivate ? '' : 'sk-...'}
-          />
+      </section>
+
+      <section className="rounded-[32px] border border-white/10 bg-white/5 p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-white">Smithery Model Context Protocol</p>
+            <p className="text-xs text-slate-300/80">
+              Link curated knowledge packs from smithery.ai to stream additional context into chat and search.
+            </p>
+          </div>
+          <Badge className="rounded-full border-white/10 bg-white/10 text-[11px] uppercase tracking-[0.3em] text-slate-200">
+            Beta
+          </Badge>
         </div>
-        <div className="grid gap-2">
-          <label htmlFor="model" className="text-sm font-medium">
-            Model
-          </label>
-          <Input
-            id="model"
-            value={localSettings.model}
-            onChange={(e) =>
-              setLocalSettings((prev) => ({
-                ...prev,
-                model: e.target.value,
-              }))
-            }
-            placeholder={isPrivate ? 'llama3.2:1b' : 'gpt-4o-mini'}
-          />
+
+        <div className="mt-4 space-y-5">
+          <div className="grid gap-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-300/70">
+              Smithery API key (optional)
+            </label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                type="password"
+                value={localSmitheryKey}
+                onChange={(event) => setLocalSmitheryKey(event.target.value)}
+                placeholder="smithery_live_..."
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleSaveSmitheryKey}
+                className="whitespace-nowrap"
+              >
+                Save key
+              </Button>
+            </div>
+            <p className="text-[11px] text-slate-400/80">
+              Required for private MCPs. Leave blank for public connectors.
+            </p>
+          </div>
+
+          <div className="grid gap-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-300/70">
+              Link a connector
+            </label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                value={newConnector}
+                onChange={(event) => setNewConnector(event.target.value)}
+                placeholder="notion-notes or https://smithery.ai/mcp/notion-notes/manifest.json"
+              />
+              <Button
+                type="button"
+                onClick={() => handleAddConnector()}
+                disabled={isSavingSmithery}
+                className="whitespace-nowrap"
+              >
+                {isSavingSmithery ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Add connector'}
+              </Button>
+            </div>
+            {smitheryError && (
+              <p className="text-xs text-red-300">{smitheryError}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xs uppercase tracking-[0.32em] text-slate-300/70">Active connectors</h3>
+              <span className="text-xs text-slate-400/70">{activeConnectors.length} enabled</span>
+            </div>
+            {smitheryServers.length === 0 ? (
+              <div className="flex items-center gap-3 rounded-3xl border border-dashed border-white/15 bg-white/5 px-4 py-4 text-xs text-slate-300/75">
+                <PlugZap className="h-4 w-4 text-sky-200" />
+                Paste a Smithery manifest URL or pick from the directory below to start streaming MCP context.
+              </div>
+            ) : (
+              <ScrollArea className="max-h-60 pr-3">
+                <div className="space-y-3">
+                  {smitheryServers.map((server) => (
+                    <div
+                      key={server.id}
+                      className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-slate-950/60 px-4 py-4 shadow-[0_18px_60px_-40px_rgba(56,189,248,0.45)] md:flex-row md:items-start md:justify-between"
+                    >
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="text-sm font-medium text-white">{server.name}</p>
+                          {server.verified && (
+                            <Badge className="flex items-center gap-1 rounded-full border-white/10 bg-emerald-400/15 text-[10px] uppercase tracking-[0.3em] text-emerald-200">
+                              <ShieldCheck className="h-3 w-3" />
+                              Verified
+                            </Badge>
+                          )}
+                          <Badge className="rounded-full border-white/10 bg-white/10 text-[10px] uppercase tracking-[0.3em] text-slate-200">
+                            {server.slug}
+                          </Badge>
+                        </div>
+                        {server.description && (
+                          <p className="text-xs text-slate-300/80">{server.description}</p>
+                        )}
+                        <div className="flex flex-wrap gap-2">
+                          {server.tags?.slice(0, 6).map((tag) => (
+                            <Badge
+                              key={`${server.id}-${tag}`}
+                              variant="outline"
+                              className="border-white/15 bg-white/5 text-[10px] uppercase tracking-[0.28em] text-slate-200"
+                            >
+                              {tag}
+                            </Badge>
+                          ))}
+                        </div>
+                        <p className="text-[11px] text-slate-400/70">
+                          Manifest:{' '}
+                          <span className="font-mono text-slate-300/90">{server.manifestUrl}</span>
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2 self-end md:self-start">
+                        <Switch
+                          checked={server.enabled !== false}
+                          onCheckedChange={(checked) => handleToggleConnector(server.id, checked)}
+                          className="data-[state=checked]:bg-sky-400/90"
+                        />
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleRefreshConnector(server)}
+                          className="gap-1"
+                        >
+                          <RefreshCcw className="h-3.5 w-3.5" />
+                          Sync
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleRemoveConnector(server.id)}
+                          className="gap-1 text-red-300 hover:text-red-200"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                          Remove
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xs uppercase tracking-[0.32em] text-slate-300/70">Smithery directory</h3>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="gap-2"
+                onClick={() => setDirectoryVersion((version) => version + 1)}
+                disabled={isDirectoryLoading}
+              >
+                <RefreshCcw className="h-3.5 w-3.5" />
+                Refresh
+              </Button>
+            </div>
+            {directoryError && <p className="text-xs text-red-300">{directoryError}</p>}
+            <ScrollArea className="max-h-48 pr-3">
+              <div className="space-y-3">
+                {isDirectoryLoading && (
+                  <div className="text-xs text-slate-300/70">Loading curated connectors…</div>
+                )}
+                {!isDirectoryLoading && directory.length === 0 && (
+                  <div className="text-xs text-slate-300/70">
+                    No public directory entries found. Save your API key if you have access to private catalogs.
+                  </div>
+                )}
+                {directory.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-slate-950/60 px-4 py-4 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div>
+                      <p className="text-sm font-medium text-white">{entry.title}</p>
+                      {entry.description && (
+                        <p className="text-xs text-slate-300/80">{entry.description}</p>
+                      )}
+                      <div className="mt-2 flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.3em] text-slate-300/70">
+                        {entry.tags?.slice(0, 4).map((tag) => (
+                          <span
+                            key={`${entry.id}-${tag}`}
+                            className="rounded-full border border-white/15 bg-white/5 px-2 py-1"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="whitespace-nowrap"
+                      onClick={() => handleAddDirectoryEntry(entry)}
+                    >
+                      Link connector
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          </div>
         </div>
-      </div>
-      <div className="mt-auto pt-4 flex justify-end gap-3">
+      </section>
+
+      <div className="mt-auto flex justify-end gap-3 pt-4">
         <Button
           variant="outline"
           onClick={() => {
@@ -135,11 +503,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
         >
           Cancel
         </Button>
-        <Button
-          onClick={handleSaveSettings}
-        >
-          Save Changes
-        </Button>
+        <Button onClick={handleSaveSettings}>Save changes</Button>
       </div>
     </div>
   );

--- a/src/renderer/src/components/SmitheryContextResults.tsx
+++ b/src/renderer/src/components/SmitheryContextResults.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ExternalLink, PlugZap, RadioTower, RefreshCcw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { SmitheryContextResult, SmitheryMCPServer } from '@/types';
+
+interface SmitheryContextResultsProps extends React.HTMLAttributes<HTMLDivElement> {
+  items: SmitheryContextResult[];
+  servers: SmitheryMCPServer[];
+  isLoading?: boolean;
+  error?: string | null;
+  onOpenSettings?: () => void;
+  onRefreshServer?: (server: SmitheryMCPServer) => Promise<void> | void;
+}
+
+const SmitheryContextResults: React.FC<SmitheryContextResultsProps> = ({
+  items,
+  servers,
+  isLoading = false,
+  error,
+  onOpenSettings,
+  onRefreshServer,
+  className,
+  ...rest
+}) => {
+  const serverMap = React.useMemo(() => {
+    return servers.reduce<Record<string, SmitheryMCPServer>>((acc, server) => {
+      acc[server.id] = server;
+      return acc;
+    }, {});
+  }, [servers]);
+
+  const activeServers = React.useMemo(
+    () => servers.filter((server) => server.enabled !== false),
+    [servers]
+  );
+
+  const renderEmptyState = () => {
+    if (activeServers.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-white/15 bg-white/5 px-6 py-10 text-center text-sm text-slate-300/80">
+          <RadioTower className="h-6 w-6 text-sky-200" aria-hidden />
+          <p className="max-w-sm text-xs text-slate-300/70">
+            Link Smithery MCP servers to stream live knowledge packs directly into search. Add a slug or manifest URL from smithery.ai in settings to get started.
+          </p>
+          <Button size="sm" variant="outline" onClick={onOpenSettings} className="pointer-events-auto">
+            Connect MCPs
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex items-center justify-between rounded-3xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-300/80">
+        <div className="flex items-center gap-2">
+          <PlugZap className="h-4 w-4 text-sky-200" aria-hidden />
+          <span>No Smithery context returned yet—try refining your query or run a deeper search.</span>
+        </div>
+        <Button size="sm" variant="ghost" onClick={onOpenSettings} className="pointer-events-auto">
+          Manage connectors
+        </Button>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className={cn(
+        'rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur-xl',
+        className
+      )}
+      {...rest}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.32em] text-slate-300/70">
+            Smithery MCP context
+          </p>
+          <h3 className="text-lg font-semibold text-white">Ambient knowledge feeds</h3>
+          <p className="text-xs text-slate-400/80">
+            Results stream from your linked Smithery servers in real-time to complement semantic search.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge
+            variant="secondary"
+            className="flex items-center gap-1 rounded-full border-white/10 bg-white/10 px-3 py-1 text-[11px] uppercase tracking-[0.18em] text-slate-200"
+          >
+            <RadioTower className="h-3.5 w-3.5" aria-hidden />
+            {activeServers.length}{' '}
+            {activeServers.length === 1 ? 'connector' : 'connectors'}
+          </Badge>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="gap-2 text-xs text-slate-200/80"
+            onClick={onOpenSettings}
+          >
+            <RefreshCcw className="h-3.5 w-3.5" aria-hidden />
+            Configure
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        {isLoading && (
+          <div className="grid gap-3 md:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Card key={`skeleton-${index}`} className="border-white/10 bg-slate-900/40">
+                <CardContent className="space-y-3 p-5">
+                  <Skeleton className="h-4 w-1/3 bg-white/10" />
+                  <Skeleton className="h-6 w-3/4 bg-white/10" />
+                  <Skeleton className="h-14 w-full bg-white/10" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && items.length === 0 && renderEmptyState()}
+
+        {!isLoading && items.length > 0 && (
+          <div className="grid gap-4 md:grid-cols-2">
+            {items.map((item) => {
+              const server = serverMap[item.serverId];
+              const serverLabel = server?.name ?? item.serverName ?? item.serverId;
+              return (
+                <Card
+                  key={item.id}
+                  className="group relative overflow-hidden border-white/10 bg-slate-950/70"
+                >
+                  <div className="pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-100"
+                    style={{
+                      background:
+                        'radial-gradient(circle at top, rgba(56,189,248,0.25), transparent 65%)',
+                    }}
+                  />
+                  <CardContent className="relative flex h-full flex-col gap-4 p-5">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-slate-300/70">
+                        <RadioTower className="h-3.5 w-3.5 text-sky-200" aria-hidden />
+                        {serverLabel}
+                      </div>
+                      {onRefreshServer && server && (
+                        <button
+                          type="button"
+                          onClick={() => onRefreshServer(server)}
+                          className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[10px] uppercase tracking-[0.18em] text-slate-200/80 transition hover:border-white/20 hover:bg-white/10"
+                        >
+                          <RefreshCcw className="h-3 w-3" aria-hidden />
+                          Sync
+                        </button>
+                      )}
+                    </div>
+                    <div className="space-y-2">
+                      <h4 className="text-base font-semibold text-white">{item.title}</h4>
+                      <p className="line-clamp-4 text-sm text-slate-300/85">{item.snippet}</p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-300/70">
+                      {item.tags?.slice(0, 4).map((tag) => (
+                        <Badge
+                          key={`${item.id}-${tag}`}
+                          variant="outline"
+                          className="border-white/15 bg-white/5 text-[10px] uppercase tracking-[0.28em] text-slate-200"
+                        >
+                          {tag}
+                        </Badge>
+                      ))}
+                      {typeof item.score === 'number' && (
+                        <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[10px] uppercase tracking-[0.28em] text-slate-200">
+                          Score {(item.score * 100).toFixed(0)}
+                        </span>
+                      )}
+                    </div>
+                    {item.url && (
+                      <Button
+                        asChild
+                        variant="ghost"
+                        size="sm"
+                        className="mt-auto w-fit gap-2 text-xs text-sky-200"
+                      >
+                        <a href={item.url} target="_blank" rel="noreferrer">
+                          Open source
+                          <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                        </a>
+                      </Button>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-xs text-red-200">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+SmitheryContextResults.displayName = 'SmitheryContextResults';
+
+export default React.memo(SmitheryContextResults);

--- a/src/renderer/src/components/navigation/KeyboardShortcuts.tsx
+++ b/src/renderer/src/components/navigation/KeyboardShortcuts.tsx
@@ -1,60 +1,57 @@
-import React from 'react'
+import React from 'react';
 
 interface KeyboardShortcutsProps {
-  showDocument: boolean
-  activePanel: 'none' | 'response' | 'document' | 'settings'
+  showDocument: boolean;
+  activePanel: 'none' | 'response' | 'document' | 'settings';
 }
 
+const shortcutsRowOne = [
+  { combo: 'Esc', label: 'Clear all' },
+  { combo: '↑↓', label: 'Navigate results' },
+  { combo: 'Enter', label: 'Ask question' },
+];
+
+const shortcutsRowTwo = [
+  { combo: '⌘/Ctrl + C', label: 'Copy context' },
+  { combo: '⌘/Ctrl + K', label: 'Open knowledgebase' },
+  { combo: '⌘/Ctrl + N', label: 'New note' },
+];
+
 export function KeyboardShortcuts({ showDocument, activePanel }: KeyboardShortcutsProps) {
+  const directionalHint =
+    activePanel === 'settings'
+      ? '← or → exit settings'
+      : showDocument
+        ? '← remove last document'
+        : '← open settings';
+
   return (
-    <div className="flex flex-col items-center mt-4 text-muted-foreground text-sm space-y-4">
-      <div className="flex justify-center space-x-6">
-        <div className="flex items-center space-x-1">
-          <kbd className="px-2 py-1 bg-muted rounded">Esc</kbd>
-          <span>Clear All</span>
-        </div>
-        <div className="flex items-center space-x-1">
-          <kbd className="px-2 py-1 bg-muted rounded">↑↓</kbd>
-          <span>Navigate</span>
-        </div>
-        {activePanel === 'settings' ? (
-          <div className="flex items-center space-x-1">
-            <kbd className="px-2 py-1 bg-muted rounded">←</kbd>
-            <span>Close Settings</span>
-          </div>
-        ) : (
-          <div className="flex items-center space-x-1">
-            <kbd className="px-2 py-1 bg-muted rounded">←</kbd>
-            <span>
-              {showDocument ? 'Remove Last Document' : 'Settings'}
-            </span>
-          </div>
-        )}
-        {activePanel === 'settings' && (
-          <div className="flex items-center space-x-1">
-            <kbd className="px-2 py-1 bg-muted rounded">→</kbd>
-            <span>Close Settings</span>
-          </div>
-        )}
-        <div className="flex items-center space-x-1">
-          <kbd className="px-2 py-1 bg-muted rounded">Enter</kbd>
-          <span>Ask Question</span>
-        </div>
+    <div className="glass-panel relative mx-auto mt-8 w-full max-w-3xl overflow-hidden rounded-[28px] border border-white/10 bg-slate-950/70 px-6 py-5 text-[13px] text-slate-200/85 shadow-[0_24px_80px_-60px_rgba(15,23,42,0.85)]">
+      <div className="pointer-events-none absolute inset-0 opacity-50" style={{ background: 'radial-gradient(circle at top left, rgba(56,189,248,0.12), transparent 55%)' }} />
+      <div className="relative flex flex-wrap items-center justify-center gap-4 sm:gap-6">
+        {[...shortcutsRowOne, { combo: directionalHint, label: 'Panel control' }].map((shortcut) => (
+          <ShortcutPill key={shortcut.combo} {...shortcut} />
+        ))}
       </div>
-      <div className="flex justify-center space-x-6">
-        <div className="flex items-center space-x-1">
-          <kbd className="px-2 py-1 bg-muted rounded">⌘/Ctrl + C</kbd>
-          <span>Copy</span>
-        </div>
-        <div className="flex items-center space-x-1">
-          <kbd className="px-2 py-1 bg-muted rounded">⌘/Ctrl + K</kbd>
-          <span>Open Knowledgebase</span>
-        </div>
-        <div className="flex items-center space-x-1">
-          <kbd className="px-2 py-1 bg-muted rounded">⌘/Ctrl + N</kbd>
-          <span>New Note</span>
-        </div>
+      <div className="relative mt-5 flex flex-wrap items-center justify-center gap-4 sm:gap-6">
+        {shortcutsRowTwo.map((shortcut) => (
+          <ShortcutPill key={shortcut.combo} {...shortcut} />
+        ))}
       </div>
     </div>
-  )
-} 
+  );
+}
+
+interface ShortcutPillProps {
+  combo: string;
+  label: string;
+}
+
+const ShortcutPill = ({ combo, label }: ShortcutPillProps) => (
+  <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-medium tracking-wide text-slate-100/90">
+    <kbd className="rounded-full border border-white/20 bg-slate-900/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-100/80">
+      {combo}
+    </kbd>
+    <span>{label}</span>
+  </div>
+);

--- a/src/renderer/src/hooks/useContextScoring.ts
+++ b/src/renderer/src/hooks/useContextScoring.ts
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { getRankedChunks, RankedChunk } from '@/lib/context-utils';
+import { getContextSimilarityScores } from '../util/trpc-client';
+import type { SearchResult } from '../types/search';
+import type { SmitheryContextResult } from '../types';
+
+type ContextDocument = {
+  content: string;
+  path: string;
+  type: 'document' | 'web' | 'mcp';
+};
+
+interface UseContextScoringOptions {
+  query: string;
+  searchResults: SearchResult[];
+  smitheryResults: SmitheryContextResult[];
+}
+
+interface UseContextScoringResult {
+  rankedChunks: RankedChunk[];
+  documentScores: Map<string, number>;
+}
+
+const buildDocuments = (
+  searchResults: SearchResult[],
+  smitheryResults: SmitheryContextResult[]
+): ContextDocument[] => {
+  const searchDocuments = searchResults.map((result) => ({
+    content: result.text,
+    path: result.metadata.path,
+    type: result.metadata.sourceType === 'web' ? 'web' : 'document',
+  }));
+
+  const smitheryDocuments = smitheryResults.map((result) => ({
+    content: result.snippet,
+    path: `mcp://${result.serverId}/${result.id}`,
+    type: 'mcp' as const,
+  }));
+
+  return [...searchDocuments, ...smitheryDocuments].filter(
+    (doc): doc is ContextDocument => Boolean(doc.content?.trim())
+  );
+};
+
+export function useContextScoring({
+  query,
+  searchResults,
+  smitheryResults,
+}: UseContextScoringOptions): UseContextScoringResult {
+  const [rankedChunks, setRankedChunks] = useState<RankedChunk[]>([]);
+  const [documentScores, setDocumentScores] = useState<Map<string, number>>(
+    () => new Map()
+  );
+  const requestIdRef = useRef(0);
+
+  const documents = useMemo(
+    () => buildDocuments(searchResults, smitheryResults),
+    [searchResults, smitheryResults]
+  );
+
+  useEffect(() => {
+    if (!query.trim() || documents.length === 0) {
+      setRankedChunks([]);
+      setDocumentScores(new Map());
+      return;
+    }
+
+    let cancelled = false;
+    const requestId = (requestIdRef.current += 1);
+
+    const updateRankedChunks = async () => {
+      try {
+        const chunks = await getRankedChunks({
+          query,
+          documents,
+          chunkSize: 500,
+          minScore: 0.1,
+        });
+
+        if (!cancelled && requestIdRef.current === requestId) {
+          setRankedChunks(chunks);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Failed to rank context chunks', error);
+          setRankedChunks([]);
+        }
+      }
+    };
+
+    updateRankedChunks();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [documents, query]);
+
+  useEffect(() => {
+    if (!query.trim() || documents.length === 0) {
+      setDocumentScores(new Map());
+      return;
+    }
+
+    let cancelled = false;
+    const requestId = (requestIdRef.current += 1);
+
+    const updateSimilarityScores = async () => {
+      try {
+        const similarityScores = await getContextSimilarityScores(
+          [query],
+          documents
+        );
+
+        if (cancelled || requestIdRef.current !== requestId) {
+          return;
+        }
+
+        const scoreMap = new Map<string, number>();
+        similarityScores.forEach((doc) => {
+          const score = doc.scores[0];
+          scoreMap.set(doc.path, score);
+        });
+
+        setDocumentScores(scoreMap);
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Error calculating similarity scores:', error);
+          setDocumentScores(new Map());
+        }
+      }
+    };
+
+    updateSimilarityScores();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [documents, query]);
+
+  return { rankedChunks, documentScores };
+}

--- a/src/renderer/src/hooks/usePersistentState.ts
+++ b/src/renderer/src/hooks/usePersistentState.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+
+const isBrowser = typeof window !== 'undefined';
+
+const resolveInitialValue = <T,>(initialValue: T | (() => T)): T =>
+  typeof initialValue === 'function'
+    ? (initialValue as () => T)()
+    : initialValue;
+
+export interface UsePersistentStateOptions<T> {
+  /**
+   * Optional serializer for persisting complex values. Defaults to JSON.stringify
+   */
+  serialize?: (value: T) => string;
+  /**
+   * Optional parser for restoring values. Defaults to JSON.parse
+   */
+  deserialize?: (value: string) => T;
+  /**
+   * Storage implementation. Defaults to window.localStorage when available.
+   */
+  storage?: Storage;
+}
+
+/**
+ * A small helper around useState that keeps the state in sync with localStorage.
+ * It gracefully handles server-side rendering and JSON parse failures.
+ */
+export function usePersistentState<T>(
+  key: string,
+  initialValue: T | (() => T),
+  options: UsePersistentStateOptions<T> = {}
+): readonly [T, Dispatch<SetStateAction<T>>, () => void] {
+  const { storage = isBrowser ? window.localStorage : undefined, serialize, deserialize } = options;
+
+  const parse = useCallback(
+    (raw: string): T => {
+      if (deserialize) {
+        return deserialize(raw);
+      }
+      return JSON.parse(raw) as T;
+    },
+    [deserialize]
+  );
+
+  const stringify = useCallback(
+    (value: T): string => {
+      if (serialize) {
+        return serialize(value);
+      }
+      return JSON.stringify(value);
+    },
+    [serialize]
+  );
+
+  const initialRef = useRef<T>();
+  if (initialRef.current === undefined) {
+    if (storage) {
+      try {
+        const storedValue = storage.getItem(key);
+        if (storedValue !== null) {
+          initialRef.current = parse(storedValue);
+        }
+      } catch (error) {
+        console.warn(`Failed to read persistent state for key "${key}"`, error);
+      }
+    }
+
+    if (initialRef.current === undefined) {
+      initialRef.current = resolveInitialValue(initialValue);
+    }
+  }
+
+  const [state, setState] = useState<T>(initialRef.current as T);
+
+  useEffect(() => {
+    if (!storage) return;
+
+    try {
+      storage.setItem(key, stringify(state));
+    } catch (error) {
+      console.warn(`Failed to write persistent state for key "${key}"`, error);
+    }
+  }, [key, state, storage, stringify]);
+
+  const reset = useCallback(() => {
+    const nextValue = resolveInitialValue(initialValue);
+    setState(nextValue);
+    if (!storage) return;
+    try {
+      storage.setItem(key, stringify(nextValue));
+    } catch (error) {
+      console.warn(`Failed to reset persistent state for key "${key}"`, error);
+    }
+  }, [initialValue, key, storage, stringify]);
+
+  return [state, setState, reset] as const;
+}

--- a/src/renderer/src/hooks/useSmitheryContext.ts
+++ b/src/renderer/src/hooks/useSmitheryContext.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { SmitheryContextResult, SmitheryMCPServer } from '../types';
+import { fetchSmitheryContext } from '../lib/smithery';
+
+interface UseSmitheryContextOptions {
+  query: string;
+  servers: SmitheryMCPServer[];
+  apiKey?: string;
+  enabled?: boolean;
+  debounceMs?: number;
+}
+
+interface UseSmitheryContextResult {
+  results: SmitheryContextResult[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Fetches Smithery MCP context for an active query while guarding against
+ * duplicate requests, stale responses, and expensive recomputations.
+ */
+export function useSmitheryContext({
+  query,
+  servers,
+  apiKey,
+  enabled = true,
+  debounceMs = 150,
+}: UseSmitheryContextOptions): UseSmitheryContextResult {
+  const [results, setResults] = useState<SmitheryContextResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  const latestRequest = useRef(0);
+
+  const activeServers = useMemo(
+    () => servers.filter((server) => server.enabled !== false),
+    [servers]
+  );
+
+  const runFetch = useCallback(async () => {
+    if (!enabled || !query.trim() || activeServers.length === 0) {
+      setResults([]);
+      setError(null);
+      setIsLoading(false);
+      if (abortRef.current) {
+        abortRef.current.abort();
+        abortRef.current = null;
+      }
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const requestId = Date.now();
+    latestRequest.current = requestId;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const aggregated: SmitheryContextResult[] = [];
+
+      for (const server of activeServers) {
+        try {
+          const items = await fetchSmitheryContext({
+            query,
+            server,
+            apiKey,
+            signal: controller.signal,
+          });
+          aggregated.push(
+            ...items.map((item) => ({
+              ...item,
+              serverId: item.serverId ?? server.id,
+              serverName: item.serverName ?? server.name ?? server.slug,
+            }))
+          );
+        } catch (innerError) {
+          if (controller.signal.aborted) {
+            return;
+          }
+
+          console.error(
+            'Smithery context fetch failed',
+            server.slug ?? server.id,
+            innerError
+          );
+
+          setError((prev) =>
+            prev ?? `Unable to sync ${server.name ?? server.slug ?? server.id}.`
+          );
+        }
+      }
+
+      if (controller.signal.aborted || latestRequest.current !== requestId) {
+        return;
+      }
+
+      setResults(aggregated);
+    } catch (outerError) {
+      if (controller.signal.aborted || latestRequest.current !== requestId) {
+        return;
+      }
+      console.error('Smithery context pipeline failed', outerError);
+      setResults([]);
+      setError('Smithery connectors are temporarily unavailable.');
+    } finally {
+      if (!controller.signal.aborted && latestRequest.current === requestId) {
+        setIsLoading(false);
+      }
+    }
+  }, [activeServers, apiKey, enabled, query]);
+
+  const scheduleFetch = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      runFetch().catch((error) => {
+        console.error('Smithery context refresh failed', error);
+      });
+    }, debounceMs);
+  }, [debounceMs, runFetch]);
+
+  useEffect(() => {
+    scheduleFetch();
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [scheduleFetch]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    await runFetch();
+  }, [runFetch]);
+
+  return {
+    results,
+    isLoading,
+    error,
+    refresh,
+  };
+}

--- a/src/renderer/src/lib/context-builder.ts
+++ b/src/renderer/src/lib/context-builder.ts
@@ -1,0 +1,55 @@
+import type { SmitheryContextResult } from '../types';
+import type { SearchResult, StickyNote } from '../types/search';
+
+interface BuildCombinedContextOptions {
+  stickyNotes: StickyNote[];
+  smitheryResults: SmitheryContextResult[];
+  searchResults: SearchResult[];
+  maxLength?: number;
+}
+
+export function buildCombinedContext({
+  stickyNotes,
+  smitheryResults,
+  searchResults,
+  maxLength = 50_000,
+}: BuildCombinedContextOptions): string {
+  let contextLength = 0;
+  let context = '';
+
+  const append = (chunk: string) => {
+    if (!chunk) return;
+    const nextLength = contextLength + chunk.length;
+    if (nextLength <= maxLength) {
+      context += chunk;
+      contextLength = nextLength;
+    }
+  };
+
+  const stickyContext = stickyNotes
+    .map((note) => {
+      const relevanceNote = ' (pinned)';
+      return `\n\nFrom ${note.metadata.path}${relevanceNote}:\n${note.text}`;
+    })
+    .join('');
+
+  append(stickyContext);
+
+  smitheryResults.forEach((result) => {
+    const title = result.title ? ` – ${result.title}` : '';
+    append(
+      `\n\nFrom Smithery MCP "${result.serverName ?? result.serverId}"${title}:\n${result.snippet}`
+    );
+  });
+
+  for (const result of searchResults) {
+    const snippet = result.text;
+    if (!snippet?.trim()) continue;
+    append(`\n\nFrom ${result.metadata.path}:\n${snippet}`);
+    if (contextLength >= maxLength) {
+      break;
+    }
+  }
+
+  return context.trim();
+}

--- a/src/renderer/src/lib/default-settings.ts
+++ b/src/renderer/src/lib/default-settings.ts
@@ -1,0 +1,23 @@
+import type { LLMSettings } from '../types';
+
+export const DEFAULT_PRIVATE_SETTINGS: Readonly<LLMSettings> = Object.freeze({
+  baseUrl: 'http://localhost:11434/v1',
+  apiKey: '',
+  model: 'llama3.2:3b',
+  modelType: 'ollama',
+});
+
+export const DEFAULT_PUBLIC_SETTINGS: Readonly<LLMSettings> = Object.freeze({
+  baseUrl: 'https://openrouter.ai/api/v1',
+  apiKey: '',
+  model: 'openai/gpt-4o-mini',
+  modelType: 'openai',
+});
+
+export const createDefaultPrivateSettings = (): LLMSettings => ({
+  ...DEFAULT_PRIVATE_SETTINGS,
+});
+
+export const createDefaultPublicSettings = (): LLMSettings => ({
+  ...DEFAULT_PUBLIC_SETTINGS,
+});

--- a/src/renderer/src/lib/smithery.ts
+++ b/src/renderer/src/lib/smithery.ts
@@ -1,0 +1,358 @@
+import type {
+  SmitheryContextResult,
+  SmitheryDirectoryEntry,
+  SmitheryManifest,
+  SmitheryMCPServer,
+} from '@/types';
+
+const DIRECTORY_ENDPOINTS = [
+  'https://smithery.ai/api/public/mcps',
+  'https://smithery.ai/api/mcps',
+  'https://smithery.ai/.well-known/mcps.json',
+];
+
+const DEFAULT_CONTEXT_LIMIT = 5;
+
+interface FetchManifestOptions {
+  identifier: string;
+  apiKey?: string;
+  signal?: AbortSignal;
+}
+
+interface FetchDirectoryOptions {
+  apiKey?: string;
+  signal?: AbortSignal;
+}
+
+interface FetchContextOptions {
+  query: string;
+  server: SmitheryMCPServer;
+  apiKey?: string;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+const createSmitheryHeaders = (apiKey?: string): Record<string, string> => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  return headers;
+};
+
+const stripJsonExtension = (value: string): string => value.replace(/\.json$/i, '');
+
+export const normaliseSmitheryIdentifier = (raw: string): string => {
+  const input = raw.trim();
+  if (!input) {
+    return '';
+  }
+
+  if (/^smithery:/i.test(input)) {
+    return stripJsonExtension(input.split(':')[1] ?? '');
+  }
+
+  if (/^https?:\/\//i.test(input)) {
+    try {
+      const url = new URL(input);
+      const segments = url.pathname.split('/').filter(Boolean);
+      const slug = segments.pop();
+      if (slug) {
+        return stripJsonExtension(slug);
+      }
+    } catch (error) {
+      console.warn('Failed to parse Smithery identifier from URL', error);
+    }
+  }
+
+  return stripJsonExtension(input);
+};
+
+const ensureIdentifier = (value: string, fallback: string): string => {
+  const identifier = normaliseSmitheryIdentifier(value || fallback);
+  if (!identifier) {
+    throw new Error('Unable to derive Smithery identifier from the provided input.');
+  }
+  return identifier;
+};
+
+export const buildSmitheryManifestUrl = (identifier: string): string => {
+  if (/^https?:\/\//i.test(identifier)) {
+    return identifier;
+  }
+  const slug = ensureIdentifier(identifier, identifier);
+  return `https://smithery.ai/api/mcps/${slug}/manifest.json`;
+};
+
+export const buildSmitheryInvokeUrl = (identifier: string): string => {
+  if (/^https?:\/\//i.test(identifier)) {
+    return identifier;
+  }
+  const slug = ensureIdentifier(identifier, identifier);
+  return `https://smithery.ai/api/mcps/${slug}/invoke`;
+};
+
+export const fetchSmitheryManifest = async ({
+  identifier,
+  apiKey,
+  signal,
+}: FetchManifestOptions): Promise<SmitheryManifest> => {
+  const manifestUrl = buildSmitheryManifestUrl(identifier);
+  const response = await fetch(manifestUrl, {
+    headers: createSmitheryHeaders(apiKey),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load Smithery manifest (${response.status} ${response.statusText}).`
+    );
+  }
+
+  const payload = await response.json();
+  const manifestPayload =
+    (payload && payload.manifest) ||
+    (payload && payload.data && payload.data.manifest) ||
+    payload;
+
+  if (!manifestPayload || typeof manifestPayload !== 'object') {
+    throw new Error('Received an invalid Smithery manifest payload.');
+  }
+
+  return {
+    identifier: normaliseSmitheryIdentifier(identifier),
+    manifestUrl,
+    payload: manifestPayload as Record<string, unknown>,
+  };
+};
+
+const normaliseTags = (raw: unknown): string[] | undefined => {
+  if (Array.isArray(raw)) {
+    return raw
+      .map((tag) => (typeof tag === 'string' ? tag : undefined))
+      .filter((tag): tag is string => Boolean(tag));
+  }
+  return undefined;
+};
+
+const normaliseDirectoryEntry = (raw: any): SmitheryDirectoryEntry => {
+  const slug = ensureIdentifier(
+    raw?.slug ?? raw?.id ?? raw?.handle ?? raw?.name ?? raw?.identifier ?? '',
+    raw?.manifest_url ?? raw?.manifestUrl ?? ''
+  );
+
+  return {
+    id: raw?.id ?? slug,
+    slug,
+    title: raw?.title ?? raw?.name ?? raw?.displayName ?? slug,
+    description: raw?.description ?? raw?.summary ?? raw?.notes ?? undefined,
+    manifestUrl:
+      raw?.manifest_url ??
+      raw?.manifestUrl ??
+      raw?.manifest ??
+      raw?.links?.manifest ??
+      buildSmitheryManifestUrl(slug),
+    queryUrl:
+      raw?.query_url ??
+      raw?.queryUrl ??
+      raw?.invoke_url ??
+      raw?.invokeUrl ??
+      raw?.links?.invoke ??
+      buildSmitheryInvokeUrl(slug),
+    tags: normaliseTags(raw?.tags ?? raw?.categories ?? raw?.capabilities),
+    verified: Boolean(raw?.verified ?? raw?.is_verified ?? raw?.trusted ?? false),
+    icon: raw?.icon ?? raw?.logo ?? raw?.thumbnail ?? raw?.image ?? undefined,
+  };
+};
+
+const extractDirectoryList = (payload: any): any[] => {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.results)) return payload.results;
+  if (Array.isArray(payload?.data?.results)) return payload.data.results;
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.servers)) return payload.servers;
+  return [];
+};
+
+export const fetchSmitheryDirectory = async ({
+  apiKey,
+  signal,
+}: FetchDirectoryOptions = {}): Promise<SmitheryDirectoryEntry[]> => {
+  let lastError: Error | null = null;
+
+  for (const endpoint of DIRECTORY_ENDPOINTS) {
+    try {
+      const response = await fetch(endpoint, {
+        headers: createSmitheryHeaders(apiKey),
+        signal,
+      });
+
+      if (!response.ok) {
+        lastError = new Error(
+          `Smithery directory request failed (${response.status} ${response.statusText}).`
+        );
+        continue;
+      }
+
+      const payload = await response.json();
+      const entries = extractDirectoryList(payload);
+      if (!entries.length) {
+        continue;
+      }
+
+      return entries.map(normaliseDirectoryEntry);
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error;
+      }
+
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  return [];
+};
+
+const resolveManifestString = (manifest: SmitheryManifest['payload']): string | undefined => {
+  const candidate =
+    typeof manifest?.manifest_url === 'string'
+      ? manifest.manifest_url
+      : typeof manifest?.manifestUrl === 'string'
+        ? manifest.manifestUrl
+        : undefined;
+
+  return candidate;
+};
+
+export const createSmitheryServerFromInput = async (
+  rawInput: string,
+  {
+    apiKey,
+    signal,
+    existing,
+  }: { apiKey?: string; signal?: AbortSignal; existing?: Partial<SmitheryMCPServer> } = {}
+): Promise<SmitheryMCPServer> => {
+  const identifier = ensureIdentifier(rawInput, existing?.slug ?? existing?.id ?? '');
+  const manifest = await fetchSmitheryManifest({ identifier, apiKey, signal });
+  const payload = manifest.payload as Record<string, any>;
+
+  const slug = ensureIdentifier(
+    payload?.slug ?? payload?.id ?? payload?.handle ?? payload?.name ?? manifest.identifier,
+    manifest.manifestUrl
+  );
+
+  const name =
+    payload?.name ?? payload?.title ?? payload?.displayName ?? existing?.name ?? slug;
+  const description =
+    payload?.description ?? payload?.summary ?? payload?.notes ?? existing?.description;
+
+  const tags =
+    normaliseTags(payload?.tags ?? payload?.categories ?? payload?.capabilities) ??
+    existing?.tags;
+
+  const queryUrl =
+    payload?.query_url ??
+    payload?.queryUrl ??
+    payload?.invoke_url ??
+    payload?.invokeUrl ??
+    payload?.endpoints?.query ??
+    payload?.links?.invoke ??
+    existing?.queryUrl ??
+    buildSmitheryInvokeUrl(slug);
+
+  const icon =
+    payload?.icon ??
+    payload?.logo ??
+    payload?.avatar ??
+    payload?.image ??
+    payload?.thumbnail ??
+    existing?.icon;
+
+  const resolvedManifestUrl =
+    resolveManifestString(payload) ?? existing?.manifestUrl ?? manifest.manifestUrl;
+
+  return {
+    id: existing?.id ?? slug,
+    slug,
+    name,
+    description,
+    manifestUrl: resolvedManifestUrl,
+    queryUrl,
+    tags,
+    icon,
+    verified: Boolean(payload?.verified ?? payload?.is_verified ?? existing?.verified ?? false),
+    enabled: existing?.enabled ?? true,
+    lastSyncedAt: new Date().toISOString(),
+  };
+};
+
+const extractContextItems = (payload: any): any[] => {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.results)) return payload.results;
+  if (Array.isArray(payload?.data?.results)) return payload.data.results;
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.items)) return payload.items;
+  return [];
+};
+
+export const fetchSmitheryContext = async ({
+  query,
+  server,
+  apiKey,
+  limit = DEFAULT_CONTEXT_LIMIT,
+  signal,
+}: FetchContextOptions): Promise<SmitheryContextResult[]> => {
+  if (!query.trim() || server.enabled === false) {
+    return [];
+  }
+
+  const endpoint = server.queryUrl ?? buildSmitheryInvokeUrl(server.slug ?? server.id);
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: createSmitheryHeaders(apiKey),
+    body: JSON.stringify({ query, limit }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Smithery context request failed (${response.status} ${response.statusText}).`
+    );
+  }
+
+  const payload = await response.json();
+  const items = extractContextItems(payload);
+
+  return items.map((item: any, index: number) => {
+    const snippet =
+      item?.snippet ??
+      item?.summary ??
+      item?.content ??
+      item?.text ??
+      item?.body ??
+      '';
+
+    const title = item?.title ?? item?.name ?? item?.heading ?? server.name;
+
+    return {
+      id: item?.id ? `${server.id}:${item.id}` : `${server.id}:${index}`,
+      serverId: server.id,
+      serverName: server.name,
+      title,
+      snippet,
+      url: item?.url ?? item?.href ?? item?.link ?? undefined,
+      score: typeof item?.score === 'number' ? item.score : undefined,
+      tags: normaliseTags(item?.tags ?? item?.categories),
+    };
+  });
+};

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -39,5 +39,48 @@ export interface AIResponse {
 }
 
 export interface ChatHistory {
-  conversations: AIResponse[]
-} 
+  conversations: AIResponse[];
+}
+
+export interface SmitheryMCPServer {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string;
+  manifestUrl: string;
+  queryUrl?: string;
+  tags?: string[];
+  icon?: string;
+  verified?: boolean;
+  enabled: boolean;
+  lastSyncedAt?: string;
+}
+
+export interface SmitheryContextResult {
+  id: string;
+  serverId: string;
+  serverName?: string;
+  title: string;
+  snippet: string;
+  url?: string;
+  score?: number;
+  tags?: string[];
+}
+
+export interface SmitheryDirectoryEntry {
+  id: string;
+  slug: string;
+  title: string;
+  description?: string;
+  manifestUrl?: string;
+  queryUrl?: string;
+  tags?: string[];
+  verified?: boolean;
+  icon?: string;
+}
+
+export interface SmitheryManifest {
+  identifier: string;
+  manifestUrl: string;
+  payload: Record<string, unknown>;
+}

--- a/src/renderer/src/types/search.ts
+++ b/src/renderer/src/types/search.ts
@@ -1,0 +1,48 @@
+export interface SearchResult {
+  text: string;
+  dist: {
+    corpus_id: number;
+    score: number;
+    text: string;
+  };
+  metadata: {
+    path: string;
+    title?: string;
+    created_at: number;
+    modified_at: number;
+    filetype: string;
+    languages: string[];
+    links: string[];
+    owner: string | null;
+    seen_at: number;
+    sourceType?: 'document' | 'web';
+  };
+  queryContext?: {
+    query: string;
+    subQueries?: Array<{
+      query: string;
+      answer: string;
+    }>;
+  };
+}
+
+export interface CachedSearch {
+  query: string;
+  results: SearchResult[];
+  timestamp: number;
+}
+
+export type PanelState = 'none' | 'settings' | 'response' | 'document' | 'chat';
+
+export type SearchState =
+  | { status: 'idle' }
+  | { status: 'searching'; query: string; shouldChat?: boolean }
+  | { status: 'searched'; query: string; results: SearchResult[] }
+  | { status: 'chatting'; query: string; results: SearchResult[] }
+  | { status: 'error'; error: string };
+
+export interface StickyNote extends SearchResult {
+  id: string;
+  position: { x: number; y: number };
+  isDragging?: boolean;
+}


### PR DESCRIPTION
## Summary
- split the Electron bootstrap into focused lifecycle helpers for the window, tray, shortcuts, and search database management
- streamline `src/main/index.ts` to use the new lifecycle modules while keeping indexing progress flowing to the renderer
- extend the README with the main-process module map and add a Smithery MCP integration guide for open-source contributors

## Testing
- `npm run lint` *(fails: ESLint v9 requires migrating to eslint.config.js which the repository has not provided yet)*

------
https://chatgpt.com/codex/tasks/task_e_68d521ba4768832db6fad8e10ba135dd